### PR TITLE
Set the correct AWS region

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -21,16 +21,16 @@ jobs:
     runs-on: ubuntu-latest
     environment: dev
     env:
-      AWS_REGION: us-east-1
+      AWS_REGION: eu-west-2
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: configure credentials
+      - name: configure credentials (using us-east-1)
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: us-east-1
       - name: Login to Public ECR
         uses: docker/login-action@v1
         with:
@@ -50,6 +50,12 @@ jobs:
           docker build -t $ECR_REPOSITORY:$IMAGE_TAG .
           docker tag $ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+      - name: configure credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
       - name: helm deploy
         uses: koslib/helm-eks-action@master
         env:


### PR DESCRIPTION
We just spell out where we're using us-east-1 because that's the only region where you can access the public AWS ECR for now but we need to use the correct AWS region elsewhere