### PR TITLE
[CKAN] Use scheming plugin

### DIFF
--- a/Dockerfile-ckan
+++ b/Dockerfile-ckan
@@ -9,9 +9,10 @@ USER root
 # Install any system packages necessary to build extensions
 # Make sure we install python 3.8, cause CKAN is not compatible with 3.9
 RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.13/main \
-        python3-dev=3.8.10-r0 
+    python3-dev=3.8.10-r0
 
 # Fetch and build the custom CKAN extensions
+RUN pip wheel --wheel-dir=/wheels git+https://github.com/ckan/ckanext-scheming@master#egg=ckanext-scheming
 RUN pip wheel --wheel-dir=/wheels git+https://github.com/Marvell-Consulting/ckanext-extrafields@main#egg=ckanext-extrafields
 
 ############
@@ -20,7 +21,7 @@ RUN pip wheel --wheel-dir=/wheels git+https://github.com/Marvell-Consulting/ckan
 FROM ghcr.io/keitaroinc/ckan:2.9.4
 
 # Add the custom extensions to the plugins list
-ENV CKAN__PLUGINS envvars image_view text_view recline_view datastore datapusher extrafields
+ENV CKAN__PLUGINS envvars image_view text_view recline_view datastore datapusher extrafields scheming_datasets 
 
 # Switch to the root user
 USER root
@@ -29,7 +30,7 @@ COPY --from=extbuild /wheels /srv/app/ext_wheels
 
 # Install and enable the custom extensions
 RUN pip install --no-index --find-links=/srv/app/ext_wheels ckanext-extrafields && \
-    ckan config-tool ${APP_DIR}/production.ini "ckan.plugins = ${CKAN__PLUGINS}" && \
+    ckan config-tool ${APP_DIR}/production.ini "ckan.plugins = ${CKAN__PLUGINS} scheming.dataset_schemas = ckanext.extrafields:ckan_dataset.yaml" && \
     chown -R ckan:ckan /srv/app
 
 # Remove wheels


### PR DESCRIPTION
What
----
Now that https://github.com/Marvell-Consulting/ckanext-extrafields/pull/1 has landed,
extrafields is essentially a shell we can use to commit schema information
ready for use by the scheming plugin.

Here we're adding the scheming plugin and then pointing the
`ckan config-tool` to set the dataset reference to
`ckanext-extrafields/ckanext/extrafields/ckan_dataset.yaml`

Why?
----

The [ckan scheming](https://github.com/ckan/ckanext-scheming) plugin provides an
easily configurable way of mofifying CKAN schemas, and making
representations of those schemas available in CKAN forms. Unless we come
up against some very custom fields, this is a good way to get going with
most of the basic needs for the registry form fields and data structure.