### PR TITLE
[CKAN] Always reinstall ckan-scheming

### DIFF
--- a/Dockerfile-ckan
+++ b/Dockerfile-ckan
@@ -12,7 +12,7 @@ RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.13/m
     python3-dev=3.8.10-r0
 
 # Fetch and build the custom CKAN extensions
-RUN pip install -e "git+https://github.com/Marvell-Consulting/ckanext-scheming.git#egg=ckanext-scheming"
+RUN pip install --force-reinstall -e "git+https://github.com/Marvell-Consulting/ckanext-scheming.git#egg=ckanext-scheming"
 
 # Add the custom extensions to the plugins list
 ENV CKAN__PLUGINS envvars image_view text_view recline_view datastore datapusher scheming_datasets


### PR DESCRIPTION
* A brute force method to ensure that the latest
  ckanext-scheming changes are pulled down and that `setup.py`
  is called
* This is to ensure changes we push to ckan-scheming are
  honoured by each deploy
* We could/should eventually define a way to ensure deploys
  are idempotent, as well as a separate update job, but for
  now they're being lumped together here