### PR TITLE
[UI] Add markdown parsing for Related Standards

### DIFF
--- a/ui/schema/index.js
+++ b/ui/schema/index.js
@@ -42,6 +42,7 @@ export default [
     },
     related_standards: {
       label: 'Related Standards',
+      format: (val) => val && <MarkdownBlock md={val} />,
     },
   },
   {


### PR DESCRIPTION
* Sometimes the references are going to be links
* Parsing markdown keeps it consistent with the other fields

### Before
<img width="657" alt="Screenshot 2021-12-10 at 14 23 41" src="https://user-images.githubusercontent.com/120181/145580851-0815e6c0-3cfe-4ce9-a2f1-b24afb0d891a.png">

### After


<img width="473" alt="Screenshot 2021-12-10 at 14 21 53" src="https://user-images.githubusercontent.com/120181/145580855-48d36092-c0c3-49fb-b04f-6b9d5d828409.png">
