### PR TITLE
[UI] Update standard listing formatting

### DIFF
--- a/ui/components/Link/index.js
+++ b/ui/components/Link/index.js
@@ -1,3 +1,7 @@
-export default function Link({ href, text }) {
-  return <a href={href}>{text || href}</a>;
+export default function Link({ href, text, newWindow = false }) {
+  return (
+    <a target={newWindow ? '_blank' : '_self'} href={href} rel="noreferrer">
+      {text || href}
+    </a>
+  );
 }

--- a/ui/components/Model/index.js
+++ b/ui/components/Model/index.js
@@ -8,7 +8,7 @@ const Rows = (props) => {
   const { options, vals, data } = props;
   return (
     <Td>
-      {Array.isArray(vals) ? (
+      {Array.isArray(vals) && vals.length > 0 ? (
         <ul className="nhsuk-list-bullet nhsuk-u-font-size-16">
           {vals.map((val, index) => (
             <li key={index}>

--- a/ui/schema/index.js
+++ b/ui/schema/index.js
@@ -1,6 +1,7 @@
 import upperFirst from 'lodash/upperFirst';
 import { Tag, Link, MarkdownBlock } from '../components';
 
+// `!!val?.length` => check whether empty array or unset val
 export default [
   {
     section_title: 'About this standard',
@@ -23,41 +24,55 @@ export default [
       label: 'Documentation',
       format: (val, data) => (
         <>
-          <MarkdownBlock md={val} />
-          <Link
-            href={data.documentation_link}
-            text="View documentation for this standard (opens in new window)"
-          />
+          {val && <MarkdownBlock md={val} />}
+          {data.documentation_link && (
+            <Link
+              href={data.documentation_link}
+              text="View documentation for this standard (opens in new window)"
+              newWindow={true}
+            />
+          )}
         </>
       ),
     },
   },
   {
     section_title: 'Business and care setting usage',
-    business_use: { label: 'Business use' },
+    business_use: {
+      label: 'Business use',
+      format: (val) => val || 'As yet unspecified',
+    },
     care_setting: {
       label: 'Care Setting',
+      format: (val) => val || 'As yet unspecified',
     },
   },
   {
     section_title: 'Relationships to other standards',
     dependencies: {
       label: 'Dependencies',
-      format: (val) => val && <MarkdownBlock md={val} />,
+      format: (val) =>
+        (!!val?.length && <MarkdownBlock md={val} />) ||
+        'Information unavailable',
     },
     related_standards: {
       label: 'Related Standards',
-      format: (val) => val && <MarkdownBlock md={val} />,
+      format: (val) =>
+        (!!val?.length && <MarkdownBlock md={val} />) ||
+        'Information unavailable',
     },
   },
   {
     section_title: 'Assurance and endorsements',
     assurance: {
       label: 'Assurance',
-      format: (val) => val && <MarkdownBlock md={val} />,
+      format: (val) =>
+        (!!val?.length && <MarkdownBlock md={val} />) || 'Not applicable',
     },
     endorsements: {
       label: 'Endorsements',
+      format: (val) =>
+        (!!val?.length && <MarkdownBlock md={val} />) || 'Not applicable',
     },
   },
 ];

--- a/ui/schema/index.js
+++ b/ui/schema/index.js
@@ -21,10 +21,15 @@ export default [
     },
     documentation_help_text: {
       label: 'Documentation',
-    },
-    documentation_link: {
-      label: 'Documentation link',
-      format: (val) => <Link href={val}></Link>,
+      format: (val, data) => (
+        <>
+          <MarkdownBlock md={val} />
+          <Link
+            href={data.documentation_link}
+            text="View documentation for this standard (opens in new window)"
+          />
+        </>
+      ),
     },
   },
   {


### PR DESCRIPTION
* Update the 'no value' generic text for each category
* Merge documentation and documentation link 
  * include generic text for each documentation link
  * update `Link` to include options to open in a new window

### before
<img width="459" alt="Screenshot 2021-12-14 at 12 59 37" src="https://user-images.githubusercontent.com/120181/146004555-afab6f31-88bc-4e91-8f9d-e3fb83187bdb.png">

### after
<img width="455" alt="Screenshot 2021-12-14 at 12 58 37" src="https://user-images.githubusercontent.com/120181/146004595-5cfa58ce-3fed-450d-9650-37b1cc5cea96.png">

Things we say when we have no value:
<img width="456" alt="Screenshot 2021-12-14 at 13 39 11" src="https://user-images.githubusercontent.com/120181/146004650-ec627421-90a8-4b4f-b090-599b7c786d3a.png">

