### PR TITLE
[UI] Add feedback footer

### DIFF
--- a/ui/components/FeedbackFooter/index.js
+++ b/ui/components/FeedbackFooter/index.js
@@ -1,0 +1,30 @@
+import Link from '../Link';
+export default function FeedbackFooter() {
+  return (
+    <>
+      <h2 id="feedback" className="nhsuk-heading-s">
+        Feedback on this page
+      </h2>
+      <p className="nhsuk-u-font-size-16">
+        To report a problem, suggest an enhancement or propose a new feature,
+        you can:
+      </p>
+      <ul className="nhsuk-list-bullet nhsuk-u-font-size-16">
+        <li>
+          email the standards directory team on{' '}
+          <Link
+            href="mailto:standardsdirectory@nhsx.nhs.uk"
+            text="standardsdirectory@nhsx.nhs.uk"
+          />
+        </li>
+        <li>
+          raise an issue on the{' '}
+          <Link
+            href="https://github.com/Marvell-Consulting/standards-community-platform-for-health-and-social-care/projects/1"
+            text="standards community development backlog on GitHub"
+          />
+        </li>
+      </ul>
+    </>
+  );
+}

--- a/ui/components/index.js
+++ b/ui/components/index.js
@@ -21,6 +21,7 @@ export { default as Tag } from './Tag';
 export { default as Layout } from './Layout';
 export { default as ReviewDates } from './ReviewDates';
 export { default as MarkdownBlock } from './MarkdownBlock';
+export { default as FeedbackFooter } from './FeedbackFooter';
 
 export { Table, Thead, Tbody, Tr, Th, Td } from './Table';
 export { Row, Col } from './Grid';

--- a/ui/pages/standards/[id].js
+++ b/ui/pages/standards/[id].js
@@ -10,6 +10,7 @@ import {
   Feedback,
   Model,
   ReviewDates,
+  FeedbackFooter,
 } from '../../components';
 import upperFirst from 'lodash/upperFirst';
 import { read } from '../../helpers/api';
@@ -31,9 +32,10 @@ const Id = ({ data }) => {
       <Row>
         <Col colspan={2}>
           <Model schema={schema} data={data} />
+          <FeedbackFooter />
           <ReviewDates data={data} />
         </Col>
-        <Col>
+        {/* <Col>
           <PanelList>
             <Details summary="Get updates for this standard">
               <EmailSignup />
@@ -42,7 +44,7 @@ const Id = ({ data }) => {
               <Feedback />
             </Details>
           </PanelList>
-        </Col>
+        </Col> */}
       </Row>
     </Page>
   );

--- a/ui/pages/standards/[id].js
+++ b/ui/pages/standards/[id].js
@@ -4,10 +4,6 @@ import {
   Reading,
   Row,
   Col,
-  PanelList,
-  Details,
-  EmailSignup,
-  Feedback,
   Model,
   ReviewDates,
   FeedbackFooter,
@@ -35,16 +31,6 @@ const Id = ({ data }) => {
           <FeedbackFooter />
           <ReviewDates data={data} />
         </Col>
-        {/* <Col>
-          <PanelList>
-            <Details summary="Get updates for this standard">
-              <EmailSignup />
-            </Details>
-            <Details summary="Give feedback about this standard">
-              <Feedback />
-            </Details>
-          </PanelList>
-        </Col> */}
       </Row>
     </Page>
   );

--- a/ui/pages/standards/index.js
+++ b/ui/pages/standards/index.js
@@ -6,6 +6,7 @@ import {
   Col,
   Filters,
   Dataset,
+  FeedbackFooter,
 } from '../../components';
 import { getPageProps } from '../../helpers/getPageProps';
 
@@ -24,6 +25,7 @@ export default function Standards({ data, schemaData }) {
         </Col>
         <Col colspan={3}>
           <Dataset data={data} pagination={true} />
+          <FeedbackFooter />
         </Col>
       </Row>
     </Page>


### PR DESCRIPTION
We have a feedback [footer in the prototype](https://nhs-standards-registry.herokuapp.com/v5/standard-mental-health). This just adds the same thing to our frontend.

Additionally I've removed the Updates/Feedback panels as they aren't in scope for MVP

On standards index page:
<img width="757" alt="Screenshot 2021-12-14 at 18 33 56" src="https://user-images.githubusercontent.com/120181/146050767-59dca6a1-ec9e-4913-aa30-1208c28e4632.png">

On Standard entry page:
<img width="807" alt="Screenshot 2021-12-14 at 18 33 49" src="https://user-images.githubusercontent.com/120181/146050773-42ddc777-2a90-454f-9c77-34f6530720a0.png">

