### PR TITLE
[UI] Fix pagination

### DIFF
--- a/ui/components/Dataset/index.js
+++ b/ui/components/Dataset/index.js
@@ -33,9 +33,6 @@ export default function Dataset({ data = {}, searchTerm, includeType }) {
 
   return (
     <>
-      <h3 className="nhsuk-heading-xs">
-        Showing {results.length} of {count} standards
-      </h3>
       <h3>
         <Snippet
           num={count}

--- a/ui/context/content.js
+++ b/ui/context/content.js
@@ -3,7 +3,6 @@ import merge from 'lodash/merge';
 
 const CONTENT = {
   title: 'Join up IT systems in health and social care',
-  browse: 'Browse the standards directory',
   filters: {
     summary: 'Showing {{num}} result{{#plural}}s{{/plural}}',
   },

--- a/ui/context/query.js
+++ b/ui/context/query.js
@@ -7,9 +7,9 @@ const QueryContext = createContext();
 export function QueryContextWrapper({ children }) {
   const router = useRouter();
 
-  function getQuery() {
+  function getQuery(props) {
     const { query } = router;
-    return stringify(query);
+    return stringify({ ...query, ...props });
   }
 
   function getSelections() {

--- a/ui/pages/standards/index.js
+++ b/ui/pages/standards/index.js
@@ -13,9 +13,7 @@ import { getPageProps } from '../../helpers/getPageProps';
 export default function Standards({ data, schemaData }) {
   return (
     <Page>
-      <h1>
-        <Snippet inline>browse</Snippet>
-      </h1>
+      <h1>Browse the standards directory</h1>
       <Reading>
         <Snippet>intro</Snippet>
         <p>


### PR DESCRIPTION
- pagination wasn't working because it worked on the assumption that `getQuery` would also potentially return an update based on query props, but I think I broke that when we were working on filters
- Also removes duplication of results summaries