### PR TITLE
[UI] approval code is now reference code

### DIFF
--- a/ui/schema/index.js
+++ b/ui/schema/index.js
@@ -9,8 +9,8 @@ export default [
       label: 'Owner',
       accessor: 'organization.title',
     },
-    approval_code: {
-      label: 'Approval Code',
+    reference_code: {
+      label: 'Reference Code',
       format: (val) => val || 'Not Applicable',
     },
     status: {


### PR DESCRIPTION
In CKAN we're using `reference_code`, but I forgot to update this on the front end 