### PR TITLE
[CKAN] init pages db using paster

### DIFF
--- a/Dockerfile-ckan
+++ b/Dockerfile-ckan
@@ -27,7 +27,10 @@ RUN ckan config-tool ${APP_DIR}/production.ini "ckanext.pages.allow_html = True"
 # RUN ckan config-tool ${APP_DIR}/production.ini "ckanext.pages.editor = medium"
 
 # https://github.com/ckan/ckanext-pages#database-initialization
-RUN ckan --config=${APP_DIR}/production.ini pages initdb
+# RUN ckan --config=${APP_DIR}/production.ini pages initdb
+# RUN ckan --config "$CONFIG" pages initdb
+RUN "$CKAN_HOME"/bin/paster --plugin=ckanext-pages pages initdb -c "${CKAN_CONFIG}/production.ini"
+
 RUN cd /srv/app/src/ckanext-scheming && python setup.py install
 RUN chown -R ckan:ckan /srv/app
 


### PR DESCRIPTION
Let's try passing in the config where possible, and see if paster does any better with finding the db connection. If this doesn't work we can try the more idiomatic version of initialisation in CKAN 2.9 e.g.

```
RUN ckan --config "$CONFIG" pages initdb
```
