### PR TITLE
[UI] Add pages to frontend

### DIFF
--- a/ui/components/MarkdownBlock/index.js
+++ b/ui/components/MarkdownBlock/index.js
@@ -14,3 +14,7 @@ export default function MarkdownBlock({ md }) {
     />
   );
 }
+
+export const MarkdownRender = ({ md }) => (
+  <div dangerouslySetInnerHTML={createMarkup(parse(md))} />
+);

--- a/ui/components/index.js
+++ b/ui/components/index.js
@@ -21,6 +21,7 @@ export { default as Tag } from './Tag';
 export { default as Layout } from './Layout';
 export { default as ReviewDates } from './ReviewDates';
 export { default as MarkdownBlock } from './MarkdownBlock';
+export { MarkdownRender } from './MarkdownBlock';
 export { default as FeedbackFooter } from './FeedbackFooter';
 
 export { Table, Thead, Tbody, Tr, Th, Td } from './Table';

--- a/ui/helpers/api.js
+++ b/ui/helpers/api.js
@@ -44,6 +44,12 @@ export async function read({ id }) {
   return data.result;
 }
 
+export async function getPages() {
+  const response = await fetch(`${CKAN_URL}/ckanext_pages_list`);
+  const data = await response.json();
+  return data.result;
+}
+
 export async function list({ page = 1, q, sort, filters }) {
   let sortstring, fq;
   const rows = 10;

--- a/ui/pages/[page].js
+++ b/ui/pages/[page].js
@@ -1,0 +1,27 @@
+import { Page, MarkdownRender } from '../components';
+
+import { getPages } from '../helpers/api';
+
+const StaticPage = ({ pageData }) => {
+  const { content, title } = pageData;
+  return (
+    <Page title={title}>
+      <h1>{title}</h1>
+      <MarkdownRender md={content} />
+    </Page>
+  );
+};
+
+export async function getServerSideProps(context) {
+  const { page } = context.params;
+  const pages = await getPages();
+  const pageData = pages.filter((i) => i.name === page).pop();
+
+  return {
+    props: {
+      pageData,
+    },
+  };
+}
+
+export default StaticPage;

--- a/ui/pages/index.js
+++ b/ui/pages/index.js
@@ -11,32 +11,56 @@ import {
   Card,
 } from '../components';
 import styles from '../styles/Home.module.scss';
+import { getPages } from '../helpers/api';
+import React from 'react';
 
 const CONTENT = {
   title: 'Join up IT systems in health and social care',
   intro:
-    'Find standards, services and APIs to build interoperable technology in health and social care.',
+    'Explore listings for information standards, services and APIs used in health and social care technology.',
 };
 
-export default function Home() {
+const Section = (section, pages) => {
+  const items = pages.filter((i) => i.homepage_section === section);
+  return (
+    <React.Fragment key={section}>
+      <h3>{section}</h3>
+      <Row>
+        {items.map((pageItem, index) => {
+          const {
+            name,
+            title,
+            homepage_snippet: snippet,
+            add_to_home_page: addToHomepage,
+          } = pageItem;
+          if (!addToHomepage) {
+            return null;
+          }
+          return (
+            <Col key={index}>
+              <Link href={`/${name}`}>
+                <a>
+                  <Card clickable className={styles.card}>
+                    <h5>{title}</h5>
+                    <p className="nhsuk-body-s">{snippet}</p>
+                  </Card>
+                </a>
+              </Link>
+            </Col>
+          );
+        })}
+      </Row>
+    </React.Fragment>
+  );
+};
+
+export default function Home({ pages }) {
+  const sections = [
+    ...new Set(pages.map((i) => i.homepage_section).filter((i) => i)),
+  ];
   return (
     <Page content={CONTENT}>
-      <h3>Directory</h3>
-      <Row>
-        <Col>
-          <Link href="/standards">
-            <a>
-              <Card clickable className={styles.card}>
-                <h5>Browse directory</h5>
-                <p className="nhsuk-body-s">
-                  Explore all standards, APIs and services
-                </p>
-              </Card>
-            </a>
-          </Link>
-        </Col>
-        <Col colspan="2"></Col>
-      </Row>
+      {sections.map((section) => Section(section, pages))}
     </Page>
   );
 }
@@ -68,6 +92,7 @@ Home.Layout = HomeLayout;
 export async function getStaticProps() {
   return {
     props: {
+      pages: await getPages(),
       content: CONTENT,
     },
   };

--- a/ui/pages/index.js
+++ b/ui/pages/index.js
@@ -58,11 +58,11 @@ export default function Home({ pages }) {
   const sections = [
     ...new Set(pages.map((i) => i.homepage_section).filter((i) => i)),
   ];
-  return (
+  return pages ? (
     <Page content={CONTENT}>
       {sections.map((section) => Section(section, pages))}
     </Page>
-  );
+  ) : null;
 }
 
 export function HomepageHero() {

--- a/ui/pages/index.js
+++ b/ui/pages/index.js
@@ -89,7 +89,7 @@ function HomeLayout({ children }) {
 
 Home.Layout = HomeLayout;
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   return {
     props: {
       pages: await getPages(),


### PR DESCRIPTION
Here we're querying `action/ckanext_pages_list` to bring back our new
static `pages` content from CKAN.

Preview tiles are rendered into the homepage and ordered by section.
This is done using js on the frontend, seeing as the Pages ckan plugin
does not have good native support for querying by new fields (see
[discussion here](https://gitter.im/ckan/chat?at=61d6fc867842bd3ca931c069)).

In order to make this work locally I've added a blank page for the
directory itself, with the specific url slug "standards". This means the
tile is added but clicking into it will hit our specific '/standards'
controller and not the [pages] one.

### Homepage

<img width="1027" alt="Screenshot 2022-01-10 at 15 22 37" src="https://user-images.githubusercontent.com/120181/148783013-74b76762-3fd3-49a9-afc0-2069cba60ade.png">

### [page] Page
<img width="1145" alt="Screenshot 2022-01-10 at 15 22 53" src="https://user-images.githubusercontent.com/120181/148783120-ba2c1f39-d81c-4d11-9541-d104f467492a.png">

