### PR TITLE
[STAN-146] UI: show contact email on standards page

### DIFF
--- a/ui/schema/index.js
+++ b/ui/schema/index.js
@@ -35,6 +35,21 @@ export default [
         </>
       ),
     },
+    contact_details: {
+      label: 'Contact details',
+      format: (val, data) => {
+        return (
+          (data.contact_details && (
+            <Link
+              href={`mailto:${data.contact_details}`}
+              text={data.contact_details}
+              newWindow={true}
+            />
+          )) ||
+          'Contact information not yet provided'
+        );
+      },
+    },
   },
   {
     section_title: 'Business and care setting usage',


### PR DESCRIPTION
## happy case
<img width="1030" alt="Screenshot 2022-01-10 at 17 33 50" src="https://user-images.githubusercontent.com/120181/148802970-962e17ab-da7e-4d49-a75a-7c201f81b1a0.png">

This is a mailto: link

## data incomplete
<img width="855" alt="Screenshot 2022-01-10 at 17 35 19" src="https://user-images.githubusercontent.com/120181/148802960-0ce5068b-2c89-407f-b1d5-2aec60385dc2.png">

We say "Contact information not yet provided"
