### PR TITLE
[UI] hide search on homepage

### DIFF
--- a/ui/components/Layout/index.js
+++ b/ui/components/Layout/index.js
@@ -54,7 +54,9 @@ export default function Home({ children, ...props }) {
               </div>
             </Col>
             <Col>
-              <Search label={false} placeholder="Search" />
+              {!props.hideSearch && (
+                <Search label={false} placeholder="Search" />
+              )}
             </Col>
           </Row>
         </div>

--- a/ui/pages/index.js
+++ b/ui/pages/index.js
@@ -81,7 +81,7 @@ export function HomepageHero() {
 
 function HomeLayout({ children }) {
   return (
-    <Layout Hero={HomepageHero} homepage>
+    <Layout Hero={HomepageHero} homepage hideSearch>
       {children}
     </Layout>
   );


### PR DESCRIPTION
Before: search is visible top right and in the centre
<img width="1081" alt="Screenshot 2022-01-10 at 17 50 51" src="https://user-images.githubusercontent.com/120181/148805653-0dfca853-17d2-4e34-ae3f-0689182fb815.png">

After: only one search on homepage
<img width="1094" alt="Screenshot 2022-01-10 at 17 51 03" src="https://user-images.githubusercontent.com/120181/148805648-a4326e28-05db-451c-b2a7-314f22456eda.png">

Nav search still shows up in all other pages