### PR TITLE
[UI] Use default CKAN sort for search

### DIFF
--- a/ui/helpers/api.js
+++ b/ui/helpers/api.js
@@ -55,9 +55,12 @@ export async function list({ page = 1, q, sort, filters }) {
   const rows = 10;
 
   const start = (page - 1) * rows;
-
+  // e.g.
+  // sort=score desc, metadata_modified desc
   if (sort) {
-    sortstring = `${sort.column} ${sort.order}`;
+    sortstring = Object.entries(sort)
+      .map((i) => i.join(' '))
+      .join(', ');
   }
 
   fq = serialise(queriseSelections(filters));

--- a/ui/helpers/getPageProps.js
+++ b/ui/helpers/getPageProps.js
@@ -3,8 +3,8 @@ import { list, schema } from './api';
 export async function getPageProps(context, options = {}) {
   const { query } = context;
   const DEFAULT_SORT = {
-    column: 'name',
-    order: 'asc',
+    score: 'desc',
+    metadata_modified: 'desc',
   };
 
   const { q, page, sort = DEFAULT_SORT, ...filters } = query;


### PR DESCRIPTION
As per the [CKAN docs](https://docs.ckan.org/en/2.9/api/index.html?highlight=facet#ckan.logic.action.get.package_search) on package search, I'm passing through a sort string, but matching the default params of score & metadata recency.

This means a. we're getting the same results as we'd get in CKAN (see third screenshot) and. b. we should be able to augment search queries easily when they come up by modifying the `sort` values.

### Before:
<img width="868" alt="Screenshot 2022-01-12 at 14 12 22" src="https://user-images.githubusercontent.com/120181/149147587-00446bfc-dc63-4018-a89b-dc975793c75f.png">

### After:
<img width="824" alt="Screenshot 2022-01-12 at 14 12 23" src="https://user-images.githubusercontent.com/120181/149147580-3111fe55-9461-44b8-b60c-7174db7ef166.png">

### Results in CKAN
<img width="868" alt="Screenshot 2022-01-12 at 14 21 20" src="https://user-images.githubusercontent.com/120181/149148458-e63c7169-9f0f-4924-a389-b5a260186a4b.png">

