### PR TITLE
[UI] Homepage and search updates

### DIFF
--- a/ui/components/Grid/index.js
+++ b/ui/components/Grid/index.js
@@ -3,7 +3,7 @@ import { Children, cloneElement } from 'react';
 
 function getClassName(total, cols) {
   if (total === 1 || total === cols) {
-    return 'nhsuk-grid-column-full';
+    return 'nhsuk-grid-column-one-half';
   }
 
   let type;
@@ -24,6 +24,7 @@ function getClassName(total, cols) {
       type = 'third';
       break;
     case 2:
+    case 1:
       type = 'half';
   }
 

--- a/ui/components/Search/index.js
+++ b/ui/components/Search/index.js
@@ -19,7 +19,10 @@ export default function Search({ placeholder, label = true }) {
       />
       <button className={classnames('nhsuk-search__submit', styles.button)}>
         <svg
-          className="nhsuk-icon nhsuk-icon__search nhsuk-u-font-size-16"
+          className={classnames(
+            'nhsuk-icon nhsuk-icon__search nhsuk-u-font-size-16',
+            styles.icon
+          )}
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"
           aria-hidden="true"

--- a/ui/components/Search/index.js
+++ b/ui/components/Search/index.js
@@ -7,7 +7,11 @@ export default function Search({ placeholder, label = true }) {
   const { query } = useQueryContext();
   const [value, setValue] = useState(query.q);
   return (
-    <form className="nhsuk-search" method="GET" action="/search-results">
+    <form
+      className={classnames('nhsuk-search', styles.search)}
+      method="GET"
+      action="/search-results"
+    >
       {label && <label className="nhsuk-label">Search</label>}
       <input
         type="text"

--- a/ui/components/Search/style.module.scss
+++ b/ui/components/Search/style.module.scss
@@ -1,9 +1,12 @@
+@import 'node_modules/nhsuk-frontend/packages/core/tools/_sass-mq.scss';
+@import 'node_modules/nhsuk-frontend/packages/core/settings/_colours.scss';
 .input {
   display: inline-block;
   padding-left: 0.5em;
   border: none;
   border-top-left-radius: 4px;
   border-bottom-left-radius: 4px;
+  background-color: $color_nhsuk-grey-5;
 }
 
 .button {
@@ -12,3 +15,28 @@
   line-height: 50%;
   right: 1%;
 }
+
+@include mq($until: tablet) {
+  .button {
+    width: 40px;
+    height: 40px;
+    padding: 1px;
+
+    // Fix escaping yellow border on search click
+    &:focus {
+      box-shadow: 0 0px #ffeb3b, 0 0px #212b32;
+    }
+  }
+  // set icon to remain at default size throughout viewport changes
+  .icon {
+    width: 27px !important;
+    height: 27px !important;
+  }
+}
+
+// Placeholder for tablet+ specific styling
+// @include mq($from: tablet) {
+//   .button {
+//     background-color: red;
+//   }
+// }

--- a/ui/components/Search/style.module.scss
+++ b/ui/components/Search/style.module.scss
@@ -10,4 +10,5 @@
   display: inline-block;
   position: absolute;
   line-height: 50%;
+  right: 1%;
 }

--- a/ui/components/Search/style.module.scss
+++ b/ui/components/Search/style.module.scss
@@ -1,5 +1,10 @@
 @import 'node_modules/nhsuk-frontend/packages/core/tools/_sass-mq.scss';
 @import 'node_modules/nhsuk-frontend/packages/core/settings/_colours.scss';
+
+.search {
+  position: relative;
+}
+
 .input {
   display: inline-block;
   padding-left: 0.5em;
@@ -13,7 +18,7 @@
   display: inline-block;
   position: absolute;
   line-height: 50%;
-  right: 1%;
+  right: -3px;
 }
 
 @include mq($until: tablet) {
@@ -36,7 +41,7 @@
 
 // Placeholder for tablet+ specific styling
 // @include mq($from: tablet) {
-//   .button {
-//     background-color: red;
-//   }
+// .button {
+// background-color: red;
+// }
 // }


### PR DESCRIPTION
## Homepage:
Don't allow tiles to spread the full width of the display column, even if they're alone on a row.

### Before
<img width="1186" alt="Screenshot 2022-01-12 at 15 43 54" src="https://user-images.githubusercontent.com/120181/149162164-38dbe246-385e-4b2b-9dc3-f5d5073999d5.png">

### After
<img width="1122" alt="Screenshot 2022-01-12 at 15 43 44" src="https://user-images.githubusercontent.com/120181/149162155-02da957c-6b6e-4956-a192-886cd4197f9f.png">

## Search styling

Fixes an issue in which the search component was escaping the bounds of the mobile viewport, also constrains the icon and hover/focus states of the component.

### Before
<img width="612" alt="Screenshot 2022-01-12 at 15 35 58" src="https://user-images.githubusercontent.com/120181/149162316-e4df7b95-89a9-415c-8c5e-590024684e5c.png">
<img width="612" alt="Screenshot 2022-01-12 at 15 35 52" src="https://user-images.githubusercontent.com/120181/149162338-a5fce125-7550-469f-bcc2-0803d7ad3d1a.png">
<img width="868" alt="Screenshot 2022-01-12 at 15 57 11" src="https://user-images.githubusercontent.com/120181/149164551-f2da1605-d8da-4c43-8dbb-cf4b15af1bb4.png">



### After
<img width="682" alt="Screenshot 2022-01-12 at 15 55 46" src="https://user-images.githubusercontent.com/120181/149164461-64116847-09de-46d4-9302-ef1e3f1cc20d.png">
<img width="682" alt="Screenshot 2022-01-12 at 15 55 42" src="https://user-images.githubusercontent.com/120181/149164482-3bde1ebc-7b0e-42c7-bf9d-cba2167bcccd.png">
<img width="868" alt="Screenshot 2022-01-12 at 15 57 42" src="https://user-images.githubusercontent.com/120181/149164678-7f7f091e-2a1d-42e1-932f-06a97aa5f2b6.png">


