### PR TITLE
[STAN-183] UI: wrap static page content in 2/3rd column 

### DIFF
--- a/ui/pages/[page].js
+++ b/ui/pages/[page].js
@@ -6,8 +6,12 @@ const StaticPage = ({ pageData }) => {
   const { content, title } = pageData;
   return (
     <Page title={title}>
-      <h1>{title}</h1>
-      <MarkdownRender md={content} />
+      <div className="nhsuk-grid-row">
+        <div className="nhsuk-grid-column-three-quarters">
+          <h1>{title}</h1>
+          <MarkdownRender md={content} />
+        </div>
+      </div>
     </Page>
   );
 };


### PR DESCRIPTION
**Before**

<img width="1045" alt="Screenshot 2022-01-21 at 13 58 45" src="https://user-images.githubusercontent.com/120181/150539542-bc7546e2-3ffa-49d5-ab6c-649ccbeea5e4.png">

Content ranges across the whole page, mismatching the [v5 proto](https://nhs-standards-registry.herokuapp.com/v5/what)

**After:**
<img width="1026" alt="Screenshot 2022-01-21 at 13 53 09" src="https://user-images.githubusercontent.com/120181/150539429-7474b008-3b00-4746-a488-1629040f2921.png">
