### PR TITLE
[STAN-171] UI: align updated info to the right

### DIFF
--- a/ui/components/Dataset/index.js
+++ b/ui/components/Dataset/index.js
@@ -3,6 +3,7 @@ import { Snippet, Tag, Flex, Pagination } from '../';
 import upperFirst from 'lodash/upperFirst';
 import format from 'date-fns/format';
 import parseISO from 'date-fns/parseISO';
+import classnames from 'classnames';
 import styles from './style.module.scss';
 
 const DATE_FORMAT = 'do MMM yyyy';
@@ -17,12 +18,17 @@ function Model({ model }) {
       </Link>
       <p>{description}</p>
       <Flex className="nhsuk-body-s">
-        <div>
-          Status: <Tag status={status}>{upperFirst(status)}</Tag>
-        </div>
-        <div>
+        <p className={classnames('nhsuk-body-s', styles.noBottom)}>
+          Status:{' '}
+          <Tag status={status} classes="nhsuk-body-s">
+            {upperFirst(status)}
+          </Tag>
+        </p>
+        <p
+          className={classnames('nhsuk-body-s', styles.right, styles.noBottom)}
+        >
           Last updated: {format(parseISO(metadata_modified), DATE_FORMAT)}
-        </div>
+        </p>
       </Flex>
     </>
   );

--- a/ui/components/Dataset/style.module.scss
+++ b/ui/components/Dataset/style.module.scss
@@ -14,3 +14,10 @@
     @include borderBottom;
   }
 }
+
+.noBottom {
+  margin-bottom: 0;
+}
+.right {
+  text-align: right;
+}

--- a/ui/components/Flex/index.js
+++ b/ui/components/Flex/index.js
@@ -3,7 +3,14 @@ import styles from './style.module.scss';
 
 export default function Flex({ children, className }) {
   return (
-    <div className={classnames('nhsuk-flex', styles.flex, className)}>
+    <div
+      className={classnames(
+        'nhsuk-flex',
+        styles.flex,
+        className,
+        styles.noBottom
+      )}
+    >
       {children}
     </div>
   );

--- a/ui/components/Flex/style.module.scss
+++ b/ui/components/Flex/style.module.scss
@@ -5,3 +5,7 @@
     flex-grow: 1;
   }
 }
+
+.noBottom {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
### Before:
<img width="700" alt="Screenshot 2022-01-21 at 14 43 46" src="https://user-images.githubusercontent.com/120181/150547061-f9b4edb3-89c5-4635-8881-c27cc5ce88f7.png">

### After:
<img width="713" alt="Screenshot 2022-01-21 at 14 42 29" src="https://user-images.githubusercontent.com/120181/150547028-dde3351a-b7b5-446a-a692-5735fd9fb7b6.png">

Additionally, I've tried to remove margin at the bottom of each listing, to try and match with what we have in the prototype. It's a first pass and (as with everything, really) can be modified based on whatever @karypun thinks