### PR TITLE
[STAN-175] UI: stop filter selections scrolling to the top

### DIFF
--- a/ui/context/query.js
+++ b/ui/context/query.js
@@ -18,7 +18,9 @@ export function QueryContextWrapper({ children }) {
 
   function updateQuery(props) {
     const { query } = router;
-    return router.push({ query: { ...query, ...props } });
+    return router.push({ query: { ...query, ...props } }, null, {
+      scroll: false,
+    });
   }
 
   const value = {


### PR DESCRIPTION
When we select filters, we're passing down a `Link` command to the router, which has accepts a [`TransitionOptions interface`](https://github.com/vercel/next.js/blob/canary/packages/next/shared/lib/router/router.ts#L53-L57): 

```
{
    shallow?: boolean;
    locale?: string | false;
    scroll?: boolean;
}
```

Here we're setting `scroll` to `false` to prevent filter selections sending the user to the top of the page.

Cf. https://stackoverflow.com/questions/65902664/next-js-router-push-without-scrolling-to-the-top?answertab=votes#tab-top 