### PR TITLE
[STAN-170] UI: show number of standards on index 

### DIFF
--- a/ui/components/Dataset/index.js
+++ b/ui/components/Dataset/index.js
@@ -4,6 +4,7 @@ import upperFirst from 'lodash/upperFirst';
 import format from 'date-fns/format';
 import parseISO from 'date-fns/parseISO';
 import styles from './style.module.scss';
+import { useQueryContext } from '../../context/query';
 
 const DATE_FORMAT = 'do MMM yyyy';
 
@@ -29,7 +30,9 @@ function Model({ model }) {
 }
 
 export default function Dataset({ data = {}, searchTerm, includeType }) {
+  const { getSelections } = useQueryContext();
   const { count = 0, results = [] } = data;
+  const filtersEmpty = Object.keys(getSelections).length === 0;
 
   return (
     <>
@@ -40,7 +43,7 @@ export default function Dataset({ data = {}, searchTerm, includeType }) {
           searchTerm={searchTerm}
           inline
         >
-          {searchTerm ? 'filters.summary' : 'filters.all'}
+          {searchTerm || !filtersEmpty ? 'filters.summary' : 'filters.all'}
         </Snippet>
       </h3>
       <ul className={styles.list}>

--- a/ui/components/Dataset/index.js
+++ b/ui/components/Dataset/index.js
@@ -32,7 +32,7 @@ function Model({ model }) {
 export default function Dataset({ data = {}, searchTerm, includeType }) {
   const { getSelections } = useQueryContext();
   const { count = 0, results = [] } = data;
-  const filtersEmpty = Object.keys(getSelections).length === 0;
+  const filtersSelected = Object.keys(getSelections).length > 0;
 
   return (
     <>
@@ -43,7 +43,7 @@ export default function Dataset({ data = {}, searchTerm, includeType }) {
           searchTerm={searchTerm}
           inline
         >
-          {searchTerm || !filtersEmpty ? 'filters.summary' : 'filters.all'}
+          {searchTerm || filtersSelected ? 'filters.summary' : 'filters.all'}
         </Snippet>
       </h3>
       <ul className={styles.list}>

--- a/ui/context/content.js
+++ b/ui/context/content.js
@@ -5,6 +5,7 @@ const CONTENT = {
   title: 'Join up IT systems in health and social care',
   filters: {
     summary: 'Showing {{num}} result{{#plural}}s{{/plural}}',
+    all: 'Showing all {{num}} result{{#plural}}s{{/plural}}',
   },
   pagination: {
     summary: 'Showing {{from}} - {{to}} of {{total}} results',


### PR DESCRIPTION
When no filters/search is added, we'll now show summary information about the number of listings we have 

<img width="1062" alt="Screenshot 2022-01-21 at 15 53 57" src="https://user-images.githubusercontent.com/120181/150558918-675fefd8-ab86-4c5a-ab15-6e66fa87349d.png">

We still show this information if we pass a search term

<img width="1039" alt="Screenshot 2022-01-21 at 15 54 16" src="https://user-images.githubusercontent.com/120181/150558906-e8c300e4-0023-481e-b703-3ea7ae01fcb8.png">
