### PR TITLE
[UI] keep logo and service name on same line

### DIFF
--- a/ui/components/Layout/index.js
+++ b/ui/components/Layout/index.js
@@ -3,6 +3,7 @@ import Head from 'next/head';
 import Link from 'next/link';
 import { Breadcrumbs, PhaseBanner, Snippet, Search, Col, Row } from '../';
 import styles from './style.module.scss';
+import classnames from 'classnames';
 
 export default function Home({ children, ...props }) {
   useRouter();
@@ -25,7 +26,10 @@ export default function Home({ children, ...props }) {
               <div className="nhsuk-header__logo">
                 <Link href="/">
                   <a
-                    className="nhsuk-header__link nhsuk-header__link--service"
+                    className={classnames(
+                      'nhsuk-header__link nhsuk-header__link--service',
+                      styles.logo
+                    )}
                     aria-label="NHS homepage"
                   >
                     <svg
@@ -46,7 +50,12 @@ export default function Home({ children, ...props }) {
                         d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"
                       ></path>
                     </svg>
-                    <span className="nhsuk-header__service-name">
+                    <span
+                      className={classnames(
+                        'nhsuk-header__service-name',
+                        styles.serviceName
+                      )}
+                    >
                       Standards directory
                     </span>
                   </a>

--- a/ui/components/Layout/style.module.scss
+++ b/ui/components/Layout/style.module.scss
@@ -1,6 +1,25 @@
 @import 'vars';
+@import 'node_modules/nhsuk-frontend/packages/core/tools/_sass-mq.scss';
+@import 'node_modules/nhsuk-frontend/packages/core/settings/_spacing.scss';
+@import 'node_modules/nhsuk-frontend/packages/core/tools/_spacing.scss';
 
 .main {
   padding-top: $nhsuk-gutter * 4;
   padding-bottom: $nhsuk-gutter * 4;
+}
+
+.logo {
+  @include mq($from: mobile) {
+    align-items: center;
+    display: flex;
+    -ms-flex-align: center;
+    margin-bottom: 0;
+    width: auto;
+  }
+}
+
+.serviceName {
+  @include mq($from: mobile) {
+    padding-left: nhsuk-spacing(3);
+  }
 }

--- a/ui/components/Search/style.module.scss
+++ b/ui/components/Search/style.module.scss
@@ -19,7 +19,7 @@
   right: 0;
 }
 
-@include mq($until: desktop) {
+@include mq($until: tablet) {
   .input {
     margin: 10px 0 0;
   }


### PR DESCRIPTION
At all sizes, ensure the logo and the service name remain
on the same line. This means adjusting the spacing between
logo and service name to be the same from tablet upwards.

**Wide desktop**
![Screenshot 2022-01-24 at 13 55 58](https://user-images.githubusercontent.com/120181/150796104-75161f23-a4b3-41ed-ad35-0a049036ee2a.png)

**Desktop**
![Screenshot 2022-01-24 cropped](https://user-images.githubusercontent.com/120181/150796414-f900cb7a-24a0-4f4c-9c06-48f0a414575b.png)

**Tablet**
![Screenshot 2022-01-24 at 13 55 41](https://user-images.githubusercontent.com/120181/150796114-ad172f68-dca5-451a-ae41-50412c40c512.png)

**Mobile**
![Screenshot 2022-01-24 at 13 55 36](https://user-images.githubusercontent.com/120181/150796117-d7a74e19-d67a-4902-875b-cbea524048db.png)

