### PR TITLE
Filtering: switch from AND to OR operators

### DIFF
--- a/ui/helpers/api.js
+++ b/ui/helpers/api.js
@@ -15,7 +15,7 @@ export function queriseSelections(selections) {
     // sanitise "Appointment / thing" => "Appointment"
     selectionsRef[prop] = selectionsRef[prop].map((i) => i.split(' ').shift());
     if (selectionsRef[prop].length) {
-      query[prop] = `(*${selectionsRef[prop].join('* AND *')}*)`;
+      query[prop] = `(*${selectionsRef[prop].join('* OR *')}*)`;
     } else {
       delete query[prop];
     }
@@ -24,7 +24,7 @@ export function queriseSelections(selections) {
 }
 
 // helper function for building SOLR Filter Queries into package_search
-// e.g. // /package_search?fq=(care_setting:(*Dentistry*%20OR%20*Community*)%20AND%20business_use:(*Continuity*))
+// e.g. // /package_search?fq=(care_setting:(*Dentistry*%20OR%20*Community*)%20OR%20business_use:(*Continuity*))
 export function serialise(obj = {}) {
   if (Object.keys(obj).length === 0) {
     return;
@@ -34,7 +34,7 @@ export function serialise(obj = {}) {
       acc.push(key + ':' + obj[key]);
       return acc;
     }, [])
-    .join(' AND ');
+    .join(' OR ');
   return `(${str})`;
 }
 


### PR DESCRIPTION
At the moment when we select filters, they send an `AND` operator to the CKAN API. If we select *Business Use* `Appointment / scheduling` and `Referrals`, that means we'll only get results if records contain *both* of those category selections.

![Screenshot 2022-01-26 at 10 53 49](https://user-images.githubusercontent.com/120181/151150727-c4aaba03-b84c-4747-8ae6-85569794d727.png)

This change will modify this behaviour so that any records which contain `Appointment / scheduling` *OR* `Referrals` will be returned.

In addition, different categories will also be joined by the `OR` operator. Meaning e.g. *Business use* and *Care setting* combinations will produce a greater number of results, rather than refining to a smaller subset.

See for example these two different queries:

[(Care setting = Dentistry AND Community) AND (Business use = Continuity)](http://a864b7b77f8e140858ab710899b7ed73-1561736528.eu-west-2.elb.amazonaws.com:5000/api/3/action/package_search?fq=(care_setting:(*Dentistry*%20AND%20*Community*)%20AND%20business_use:(*Continuity*))) (0 results)

[(Care setting = Dentistry OR Community) OR (Business use = Continuity)](http://a864b7b77f8e140858ab710899b7ed73-1561736528.eu-west-2.elb.amazonaws.com:5000/api/3/action/package_search?fq=(care_setting:(*Dentistry*%20OR%20*Community*)%20OR%20business_use:(*Continuity*))) (54 results)


