### PR TITLE
[STAN-235] UI: update listing page update

### DIFF
--- a/ui/components/Grid/index.js
+++ b/ui/components/Grid/index.js
@@ -47,7 +47,8 @@ export function Row({ children, className }) {
   );
 }
 
-export function Col({ children, total, colspan }) {
-  const className = getClassName(total, colspan);
-  return <div className={className}>{children}</div>;
+export function Col({ children, total, colspan, className }) {
+  return (
+    <div className={className || getClassName(total, colspan)}>{children}</div>
+  );
 }

--- a/ui/components/Paragraph/index.js
+++ b/ui/components/Paragraph/index.js
@@ -1,0 +1,3 @@
+export default function Paragraph({ children, className }) {
+  return <p className={className || 'nhsuk-u-font-size-16'}>{children}</p>;
+}

--- a/ui/components/index.js
+++ b/ui/components/index.js
@@ -12,6 +12,7 @@ export { default as Model } from './Model';
 export { default as OptionSelect } from './OptionSelect';
 export { default as Page } from './Page';
 export { default as Pagination } from './Pagination';
+export { default as Paragraph } from './Paragraph';
 export { default as PanelList } from './PanelList';
 export { default as PhaseBanner } from './PhaseBanner';
 export { default as Reading } from './Reading';

--- a/ui/pages/standards/[id].js
+++ b/ui/pages/standards/[id].js
@@ -26,7 +26,7 @@ const Id = ({ data }) => {
         </div>
       </Reading>
       <Row>
-        <Col colspan={2}>
+        <Col className="nhsuk-grid-column-two-thirds">
           <Model schema={schema} data={data} />
           <FeedbackFooter />
           <ReviewDates data={data} />

--- a/ui/pages/standards/[id].js
+++ b/ui/pages/standards/[id].js
@@ -1,5 +1,4 @@
 import {
-  Tag,
   Page,
   Reading,
   Row,
@@ -8,7 +7,7 @@ import {
   ReviewDates,
   FeedbackFooter,
 } from '../../components';
-import upperFirst from 'lodash/upperFirst';
+
 import { read } from '../../helpers/api';
 import schema from '../../schema';
 
@@ -16,10 +15,7 @@ const Id = ({ data }) => {
   return (
     <Page title={data.title}>
       <Reading>
-        <h2 className="nhsuk-caption-l">
-          <Tag status={data.status}>{upperFirst(data.status)}</Tag> Information
-          standard listing
-        </h2>
+        <h2 className="nhsuk-caption-l">{data.standard_category}</h2>
         <h1>{data.title}</h1>
         <div className="nhsuk-u-reading-width">
           <p>{data.description}</p>

--- a/ui/schema/index.js
+++ b/ui/schema/index.js
@@ -51,11 +51,15 @@ export default [
         <>
           {val && <MarkdownBlock md={val} />}
           {data.documentation_link && (
-            <Link
-              href={data.documentation_link}
-              text="View documentation for this standard (opens in new window)"
-              newWindow={true}
-            />
+            <>
+              <Link
+                href={data.documentation_link}
+                text="View documentation for this standard"
+                newWindow={true}
+              />
+              <br />
+              (opens in new window)
+            </>
           )}
         </>
       ),

--- a/ui/schema/index.js
+++ b/ui/schema/index.js
@@ -1,5 +1,5 @@
 import upperFirst from 'lodash/upperFirst';
-import { Tag, Link, MarkdownBlock } from '../components';
+import { Details, Tag, Link, MarkdownBlock, Paragraph } from '../components';
 
 // `!!val?.length` => check whether empty array or unset val
 export default [
@@ -9,13 +9,38 @@ export default [
       label: 'Owner',
       accessor: 'organization.title',
     },
-    reference_code: {
-      label: 'Reference Code',
-      format: (val) => val || 'Not Applicable',
-    },
     status: {
       label: 'Status',
-      format: (val) => <Tag status={val.toLowerCase()}>{upperFirst(val)}</Tag>,
+      format: (val) => (
+        <>
+          <Tag status={val.toLowerCase()}>{upperFirst(val)}</Tag>
+          {
+            <Details
+              className="nhsuk-u-font-size-16 nhsuk-u-margin-top-4"
+              summary="What this status means"
+            >
+              <div className="nhsuk-details__text">
+                <Paragraph>
+                  <strong>Active standards</strong> are stable, maintained and
+                  have been assured or endorsed for use by qualified bodies.
+                </Paragraph>
+                <Paragraph>
+                  <strong>Draft standards</strong> are still being developed or
+                  are waiting for assurance or endorsement by qualified bodies.
+                </Paragraph>
+                <Paragraph>
+                  <strong>Deprecated standards</strong> are older versions of a
+                  standard which are being phased out.
+                </Paragraph>
+                <Paragraph>
+                  <strong>Retired standards</strong> are not being maintained
+                  and should not be used.
+                </Paragraph>
+              </div>
+            </Details>
+          }
+        </>
+      ),
     },
     standard_category: {
       label: 'Type of standard',
@@ -79,6 +104,10 @@ export default [
   },
   {
     section_title: 'Assurance and endorsements',
+    reference_code: {
+      label: 'Reference Code',
+      format: (val) => val || 'Not Applicable',
+    },
     assurance: {
       label: 'Assurance',
       format: (val) =>


### PR DESCRIPTION
**New!** 
What this status means Details:
<img width="755" alt="Screenshot 2022-02-15 at 14 42 14" src="https://user-images.githubusercontent.com/120181/154074111-5446cd9b-2530-4b99-8ebf-00f9b37659af.png">
<img width="809" alt="Screenshot 2022-02-15 at 14 42 18" src="https://user-images.githubusercontent.com/120181/154074101-832dd9d0-5082-4a82-bf02-cd3900d709ec.png">

**Banished!**
Tag removed on heading caption

<img width="736" alt="Screenshot 2022-02-15 at 14 42 21" src="https://user-images.githubusercontent.com/120181/154074285-a2ab2dc0-8708-4118-8fbb-3b2aec271024.png">

**Slightly altered!**
Reference code dropped down into Assurance section. (There's more work to be done here but we should talk about the best way of updating assurance information)
<img width="794" alt="Screenshot 2022-02-15 at 14 43 34" src="https://user-images.githubusercontent.com/120181/154074362-e78277a6-6707-48d1-873f-7159f17839f5.png">

