### PR TITLE
[CKAN] Add cronjobs to dockerfile

### DIFF
--- a/Dockerfile-ckan
+++ b/Dockerfile-ckan
@@ -36,7 +36,8 @@ RUN chown -R ckan:ckan /srv/app
 # Create the log file to be able to run tail
 RUN touch /var/log/cron.log
 # run at midnight every night
-RUN crontab -l | { ckan ; echo "0 0 * * * ckan --config=${APP_DIR}/production.ini search-index rebuild entry" >> /var/log/cron.log } | crontab -
+RUN crontab -l > rebuild-index-cron
+RUN echo "0 0 * * * ckan --config=${APP_DIR}/production.ini search-index rebuild entry" >> rebuild-index-cron && crontab rebuild-index-cron
 
 # Run the command on container startup
 CMD cron && tail -f /var/log/cron.log

--- a/Dockerfile-ckan
+++ b/Dockerfile-ckan
@@ -32,5 +32,14 @@ RUN cd /srv/app/src/ckanext-pages && python setup.py install
 
 RUN chown -R ckan:ckan /srv/app
 
+# Setup cron jobs
+# Create the log file to be able to run tail
+RUN touch /var/log/cron.log
+# run at midnight every night
+RUN crontab -l | { ckan ; echo "0 0 * * * ckan --config=${APP_DIR}/production.ini search-index rebuild entry" >> /var/log/cron.log } | crontab -
+
+# Run the command on container startup
+CMD cron && tail -f /var/log/cron.log
+
 # Switch to the ckan user
 USER ckan

--- a/Dockerfile-ckan
+++ b/Dockerfile-ckan
@@ -23,6 +23,8 @@ RUN ckan config-tool ${APP_DIR}/production.ini "ckan.plugins = ${CKAN__PLUGINS}"
 RUN ckan config-tool ${APP_DIR}/production.ini "scheming.dataset_schemas = ckanext.scheming:ckan_dataset.yaml"
 RUN ckan config-tool ${APP_DIR}/production.ini "scheming.organization_schemas = ckanext.scheming:org_with_email.json"
 RUN ckan config-tool ${APP_DIR}/production.ini "ckanext.pages.allow_html = True"
+# https://docs.ckan.org/en/2.9/maintaining/tracking.html
+RUN ckan config-tool ${APP_DIR}/production.ini "ckan.tracking_enabled = True"
 
 RUN cd /srv/app/src/ckanext-scheming && python setup.py install
 RUN cd /srv/app/src/ckanext-pages && python setup.py install
@@ -37,7 +39,7 @@ RUN chown -R ckan:ckan /srv/app
 RUN touch /var/log/cron.log
 # run at midnight every night
 RUN crontab -l > rebuild-index-cron
-RUN echo "0 0 * * * ckan --config=${APP_DIR}/production.ini search-index rebuild entry" >> rebuild-index-cron && crontab rebuild-index-cron
+RUN echo "@hourly ckan -c ${APP_DIR}/production.ini tracking update && ckan -c ${APP_DIR}/production.ini search-index rebuild -r" >> rebuild-index-cron
 
 # Run the command on container startup
 CMD cron && tail -f /var/log/cron.log


### PR DESCRIPTION
* Adds page tracking: https://docs.ckan.org/en/2.9/maintaining/tracking.html
* Sets up cronjobs directly on the ckan machine, though we can probably update this to use kubectl CronJob deployments in the future
* Search Indexes and page tracking information is rebuilt hourly
