### PR TITLE
[CKAN] use crontab as cron is not on the image

### DIFF
--- a/Dockerfile-ckan
+++ b/Dockerfile-ckan
@@ -35,14 +35,9 @@ RUN cd /srv/app/src/ckanext-pages && python setup.py install
 RUN chown -R ckan:ckan /srv/app
 
 # Setup cron jobs
-# Create the log file to be able to run tail
-RUN touch /var/log/cron.log
-# run at midnight every night
 RUN crontab -l > rebuild-index-cron
 RUN echo "@hourly ckan -c ${APP_DIR}/production.ini tracking update && ckan -c ${APP_DIR}/production.ini search-index rebuild -r" >> rebuild-index-cron
-
-# Run the command on container startup
-CMD cron && tail -f /var/log/cron.log
+RUN crontab rebuild-index-cron && rm rebuild-index-cron
 
 # Switch to the ckan user
 USER ckan


### PR DESCRIPTION
A quick followup on the cron job: cron is not on the ckan image, but crontab is. Let's just use crontab