### PR TITLE
[STAN-410] run cronjobs popularity and search

### DIFF
--- a/Dockerfile-ckan
+++ b/Dockerfile-ckan
@@ -29,25 +29,7 @@ RUN ckan config-tool ${APP_DIR}/production.ini "ckan.tracking_enabled = True"
 RUN cd /srv/app/src/ckanext-scheming && python setup.py install
 RUN cd /srv/app/src/ckanext-pages && python setup.py install
 
-# https://github.com/ckan/ckanext-pages#database-initialization
-# RUN CKAN_SOLR_URL=http://solr-headless:8983/solr ckan -c ${APP_DIR}/production.ini pages initdb
-
 RUN chown -R ckan:ckan /srv/app
-
-# Setup cron jobs
-# crond needs root, so install dcron and cap package and set the capabilities
-# on dcron binary https://github.com/inter169/systs/blob/master/alpine/crond/README.md
-RUN apk add --no-cache dcron libcap && \
-    chown ckan:ckan /usr/sbin/crond && \
-    setcap cap_setgid=ep /usr/sbin/crond
-
-RUN touch crontab.tmp \
-    && echo '0 * * * * ckan -c ${APP_DIR}/production.ini tracking update && ckan -c ${APP_DIR}/production.ini search-index rebuild -r' > crontab.tmp \
-    && crontab -u ckan crontab.tmp \
-    && rm -rf crontab.tmp
-
-# Run the crontab
-CMD ["/usr/sbin/crond" "-l", "/dev/stdout"]
 
 # Switch to the ckan user
 USER ckan

--- a/Dockerfile-ckan
+++ b/Dockerfile-ckan
@@ -44,10 +44,10 @@ RUN apk add --no-cache dcron libcap && \
 RUN touch crontab.tmp \
     && echo '0 * * * * ckan -c ${APP_DIR}/production.ini tracking update && ckan -c ${APP_DIR}/production.ini search-index rebuild -r' > crontab.tmp \
     && crontab -u ckan crontab.tmp \
-    && rm -rf crontab.tmp 
+    && rm -rf crontab.tmp
 
 # Run the crontab
-CMD ["/usr/sbin/crond"]
+CMD ["/usr/sbin/crond" "-l", "/dev/stdout"]
 
 # Switch to the ckan user
 USER ckan

--- a/charts/ckan/templates/ckan-cli-cronjob.yaml
+++ b/charts/ckan/templates/ckan-cli-cronjob.yaml
@@ -1,0 +1,71 @@
+{{- $top := . }}
+{{- if hasKey .Values "cronjobs" }}
+{{- range .Values.cronjobs }}
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ .name }}
+spec:
+  schedule: "{{ .schedule }}"
+  successfulJobsHistoryLimit: 0
+  failedJobsHistoryLimit: 2
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: {{ .name }}
+            image: {{ .image }}
+            args:
+            {{- range .args }}
+            - {{ . }}
+            {{- end }}
+            {{- if hasKey . "env" }}
+            env:
+            - name: CKAN_SYSADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ckancredentials
+                  key: sysadminPassword
+            - name: CKAN__SITE_TITLE
+              value: {{ .Values.ckan.siteTitle }}
+            - name: PSQL_MASTER
+              value: {{ .Values.ckan.psql.masterUser }}
+            - name: PSQL_PASSWD
+              valueFrom:
+                secretKeyRef:
+                  name: ckancredentials
+                  key: psqlMasterPassword
+            - name: CKAN_SQLALCHEMY_URL
+              valueFrom:
+                secretKeyRef:
+                  name: ckancredentials
+                  key: ckanSqlAlchemyUrl
+            - name: CKAN_DATASTORE_WRITE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: ckancredentials
+                  key: ckanDatastoreWriteUrl
+            - name: CKAN_DATASTORE_READ_URL
+              valueFrom:
+                secretKeyRef:
+                  name: ckancredentials
+                  key: ckanDatastoreReadUrl
+            - name: CKAN_SOLR_URL
+              value: {{ .Values.ckan.solr }}
+            - name: CKAN__DATAPUSHER__URL
+              value: {{ .Values.ckan.datapusherUrl }}
+            {{- range .env }}
+            - name: {{ .name }}
+              value: {{ .value }}
+            {{- end }}
+
+            {{- end }}
+          {{- if hasKey $top.Values "imagePullSecret" }}
+          imagePullSecrets:
+          - name: {{ $top.Values.imagePullSecret }}
+          {{- end }}
+          restartPolicy: OnFailure
+{{- end }}
+{{- end }}

--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -296,3 +296,28 @@ solr:
 postgresql:
   # postgresql.enabled -- Flag to control whether to deploy PostgreSQL
   enabled: false
+
+# See https://github.com/datopian/ckan-cloud-helm/blob/master/ckan/templates/cronjobs.yaml for details
+cronjobs:
+  - name: ckan-tracking
+    # image: viderum/ckan-cloud-docker:ckan-v0.0.9
+    image: keitaro/ckan:2.9.2
+    # hourly
+    schedule: '0 * * * *'
+    args:
+      - ckan
+      - -c
+      - production.ini
+      - tracking
+      - update
+  - name: ckan-search-rebuilder
+    image: keitaro/ckan:2.9.2
+    # nightly at midnight
+    schedule: '0 0 * * *' 
+    args:
+      - ckan
+      - -c
+      - production.ini
+      - search-index
+      - rebuild
+      - -r


### PR DESCRIPTION
### Add a new cronjob template and values
- For each cronjob run a blank keitaro ckan image and pass a command
- keep 2x failing pods, remove if successful
- should run search index rebuilds nightly and [CKAN page view tracking every hour](https://docs.ckan.org/en/2.9/maintaining/tracking.html)

