### PR TITLE
[STAN-410] try a direct swap to marv helm chart for ckan deploy

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -103,7 +103,7 @@ jobs:
           IMAGE_TAG: dev-ckan-${{ github.sha }}
         with:
           command: >-
-            helm upgrade ckan -n dev --repo https://keitaro-charts.storage.googleapis.com --install --wait ckan -f ./charts/ckan/values.yaml
+            helm upgrade ckan -n dev --repo https://marvell-consulting.github.io/ckan-helm-chart --install --wait ckan -f ./charts/ckan/values.yaml
             --set ckan.sysadminApiToken='${{ secrets.CKAN_SYSADMIN_API_TOKEN }}'
             --set ckan.sysadminName='${{ secrets.CKAN_SYSADMIN_NAME }}'
             --set ckan.sysadminPassword='${{ secrets.CKAN_SYSADMIN_PASS }}'


### PR DESCRIPTION
Now that we have some versions of our own [ckan helm chart](https://github.com/Marvell-Consulting/ckan-helm-chart) published (see https://api.github.com/repos/Marvell-Consulting/ckan-helm-chart/releases for more) we should be able to use this to deploy dev, and hopefully get [cronjob-cli](https://github.com/Marvell-Consulting/ckan-helm-chart/blob/main/charts/ckan/templates/cronjob-cli.yaml) running