### PR TITLE
[STAN-410] Use marv charts in test and prod

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -103,7 +103,7 @@ jobs:
           IMAGE_TAG: prod-ckan-${{ github.sha }}
         with:
           command: >-
-            helm upgrade --debug ckan -n prod --repo https://keitaro-charts.storage.googleapis.com --install --wait ckan -f ./charts/ckan/values.yaml
+            helm upgrade --debug ckan -n prod --repo https://marvell-consulting.github.io/ckan-helm-chart --install --wait ckan -f ./charts/ckan/values.yaml
             --set ckan.sysadminName='${{ secrets.CKAN_SYSADMIN_NAME }}'
             --set ckan.sysadminPassword='${{ secrets.CKAN_SYSADMIN_PASS }}'
             --set ckan.db.ckanDbPassword='${{ secrets.CKAN_DB_PASS }}'

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -105,7 +105,7 @@ jobs:
           IMAGE_TAG: test-ckan-${{ github.sha }}
         with:
           command: >-
-            helm upgrade ckan --debug -n test --repo https://keitaro-charts.storage.googleapis.com --install --wait ckan -f ./charts/ckan/values.yaml
+            helm upgrade ckan --debug -n test --repo https://marvell-consulting.github.io/ckan-helm-chart --install --wait ckan -f ./charts/ckan/values.yaml
             --set ckan.siteUrl='${{ secrets.CKAN_SITE_URL }}'
             --set ckan.psql.masterPassword='${{ secrets.MASTER_DB_PASS }}'
             --set ckan.db.ckanDbPassword='${{ secrets.CKAN_DB_PASS }}'


### PR DESCRIPTION
Deploying using [our version of the keitaro ckan helm chart](https://marvell-consulting.github.io/ckan-helm-chart/) seems to have done what we were after in dev by adding some additional cron jobs:

<img width="1024" alt="Screenshot 2022-03-23 at 15 05 59" src="https://user-images.githubusercontent.com/120181/159718002-5261b118-e0cf-4982-a88a-dd5d7740d5b1.png">

Here we're updating `test` and `prod` deployments to do the same thing