### PR TITLE
Tell bots (i.e. google) not to index us

### DIFF
--- a/ui/components/Layout/index.js
+++ b/ui/components/Layout/index.js
@@ -1,9 +1,20 @@
 import { useRouter } from 'next/router';
 import Head from 'next/head';
 import Link from 'next/link';
-import { Analytics, Breadcrumbs, PhaseBanner, Snippet, Search, Col, Row } from '../';
+import {
+  Analytics,
+  Breadcrumbs,
+  PhaseBanner,
+  Snippet,
+  Search,
+  Col,
+  Row,
+} from '../';
 import styles from './style.module.scss';
 import classnames from 'classnames';
+
+const nofollow = (env) =>
+  env !== 'production' ? <meta name="robots" content="none" /> : null;
 
 export default function Home({ children, ...props }) {
   useRouter();
@@ -14,6 +25,7 @@ export default function Home({ children, ...props }) {
           <Snippet>title</Snippet>
         </title>
         <link rel="icon" href="/favicon.png" />
+        {nofollow(process.env.NODE_ENV)}
       </Head>
       <a className="nhsuk-skip-link" href="#maincontent">
         Skip to main content


### PR DESCRIPTION
* Defensive measure given we have a huge "Deceptive site ahead" warning on dev.nhs.marvell-consulting
* if env is production, allow tracking
Done using ```<meta name="robots" content="none" />``` tag
see https://developers.google.com/search/docs/advanced/robots/robots_meta_tag#none for more

## In development
`npm run dev`:

<img width="414" alt="Screenshot 2022-04-05 at 11 54 51" src="https://user-images.githubusercontent.com/120181/161732073-288966df-4e6a-4575-8ee9-b978b135a2bc.png">

## In production
`npm run build && npm run start`

<img width="879" alt="Screenshot 2022-04-05 at 12 12 14" src="https://user-images.githubusercontent.com/120181/161732256-0503c98a-e22d-457c-91c6-294b7de8e75e.png">

