### PR TITLE
Set up details component for standard type

### DIFF
--- a/ui/components/Expander/index.js
+++ b/ui/components/Expander/index.js
@@ -1,0 +1,23 @@
+import classnames from 'classnames';
+
+export default function Expander({ summary, children, className, small, open }) {
+  return (
+    <details
+      className={classnames('nhsuk-details nhsuk-expander', className)}
+      open={open || false}
+    >
+      <summary className="nhsuk-details__summary">
+        <span
+          className={classnames('nhsuk-details__summary-text', {
+            'nhsuk-body-s': small,
+          })}
+        >
+          {summary}
+        </span>
+      </summary>
+      <div className="nhsuk-details__text">
+        {children}
+      </div>
+    </details>
+  );
+}

--- a/ui/components/Filters/index.js
+++ b/ui/components/Filters/index.js
@@ -1,5 +1,5 @@
 import { useQueryContext } from '../../context/query';
-import { CheckboxGroup, OptionSelect, Details, PanelList } from '../';
+import { CheckboxGroup, OptionSelect, Expander, PanelList } from '../';
 
 function Filter({
   label,
@@ -9,7 +9,7 @@ function Filter({
   hasChecked,
 }) {
   return (
-    <Details summary={label} className="nhsuk-filter" open={hasChecked}>
+    <Expander summary={label} className="nhsuk-filter" open={hasChecked}>
       <OptionSelect>
         <CheckboxGroup
           onChange={onChange}
@@ -18,7 +18,7 @@ function Filter({
           small
         />
       </OptionSelect>
-    </Details>
+    </Expander>
   );
 }
 
@@ -93,9 +93,11 @@ export default function Filters({ schema }) {
     <div className="nhsuk-filters">
       <h3>Filters</h3>
       <PanelList>
+        <div className="nhsuk-expander-group">
         {filters.map((filter, index) => (
           <Filter key={index} {...filter} onChange={setItem} />
         ))}
+        </div>
       </PanelList>
     </div>
   );

--- a/ui/components/Layout/index.js
+++ b/ui/components/Layout/index.js
@@ -1,7 +1,16 @@
 import { useRouter } from 'next/router';
 import Head from 'next/head';
 import Link from 'next/link';
-import { Analytics, Breadcrumbs, PhaseBanner, Snippet, Search, Col, Row } from '../';
+import {
+  Analytics,
+  Breadcrumbs,
+  Navigation,
+  PhaseBanner,
+  Snippet,
+  Search,
+  Col,
+  Row
+} from '../';
 import styles from './style.module.scss';
 import classnames from 'classnames';
 
@@ -69,7 +78,9 @@ export default function Home({ children, ...props }) {
             </Col>
           </Row>
         </div>
+        <Navigation />
       </header>
+
 
       <Breadcrumbs
         labels={{

--- a/ui/components/Layout/index.js
+++ b/ui/components/Layout/index.js
@@ -93,7 +93,7 @@ export default function Home({ children, ...props }) {
 
       <PhaseBanner homepage={props.homepage} />
 
-      {props.Hero && <props.Hero />}
+      {props.Hero && <props.Hero {...props} />}
 
       <div className="nhsuk-width-container">
         <main className={styles.main} id="maincontent" role="main">

--- a/ui/components/Layout/style.module.scss
+++ b/ui/components/Layout/style.module.scss
@@ -1,7 +1,7 @@
 @import 'vars';
-@import 'node_modules/nhsuk-frontend/packages/core/tools/_sass-mq.scss';
-@import 'node_modules/nhsuk-frontend/packages/core/settings/_spacing.scss';
-@import 'node_modules/nhsuk-frontend/packages/core/tools/_spacing.scss';
+@import 'node_modules/nhsuk-frontend/packages/core/tools/_all.scss';
+@import 'node_modules/nhsuk-frontend/packages/core/settings/_all.scss';
+@import 'node_modules/nhsuk-frontend/packages/components/header/_header.scss';
 
 .main {
   padding-top: $nhsuk-gutter * 4;

--- a/ui/components/Navigation/index.js
+++ b/ui/components/Navigation/index.js
@@ -1,6 +1,4 @@
-import classnames from 'classnames';
 import Link from 'next/link';
-import styles from './style.module.scss';
 
 export default function Navigation() {
 
@@ -34,7 +32,7 @@ export default function Navigation() {
         <ul className="nhsuk-header__navigation-list">
           {
             links.map(link => (
-              <li className="nhsuk-header__navigation-item">
+              <li className="nhsuk-header__navigation-item" key={link.label}>
                 <Link href={link.url}>
                   <a className="nhsuk-header__navigation-link">{ link.label }</a>
                 </Link>

--- a/ui/components/Navigation/index.js
+++ b/ui/components/Navigation/index.js
@@ -8,7 +8,7 @@ export default function Navigation() {
       url: '/standards'
     },
     {
-      label: 'Roadmap',
+      label: 'Upcoming standards',
       url: '#'
     },
     {

--- a/ui/components/Navigation/index.js
+++ b/ui/components/Navigation/index.js
@@ -9,15 +9,15 @@ export default function Navigation() {
     },
     {
       label: 'Upcoming standards',
-      url: '#'
+      url: '/roadmap'
     },
     {
       label: 'Standards guidance',
-      url: '#'
+      url: '/what-information-standards-are'
     },
     {
       label: 'Community',
-      url: '#'
+      url: '/community'
     }
   ]
 

--- a/ui/components/Navigation/index.js
+++ b/ui/components/Navigation/index.js
@@ -7,7 +7,7 @@ export default function Navigation() {
   const links = [
     {
       label: 'Directory',
-      url: '#'
+      url: '/standards'
     },
     {
       label: 'Roadmap',

--- a/ui/components/Navigation/index.js
+++ b/ui/components/Navigation/index.js
@@ -1,0 +1,49 @@
+import classnames from 'classnames';
+import Link from 'next/link';
+import styles from './style.module.scss';
+
+export default function Navigation() {
+
+  const links = [
+    {
+      label: 'Directory',
+      url: '#'
+    },
+    {
+      label: 'Roadmap',
+      url: '#'
+    },
+    {
+      label: 'Standards guidance',
+      url: '#'
+    },
+    {
+      label: 'Community',
+      url: '#'
+    }
+  ]
+
+  return (
+    <nav className="nhsuk-header__navigation" id="header-navigation" role="navigation" aria-label="Primary navigation" aria-labelledby="label-navigation">
+      <div className="nhsuk-width-container">
+        <p className="nhsuk-header__navigation-title"><span id="label-navigation">Menu</span>
+          <button className="nhsuk-header__navigation-close" id="close-menu">
+            <span className="nhsuk-u-visually-hidden">Close menu</span>
+          </button>
+        </p>
+        <ul className="nhsuk-header__navigation-list">
+          {
+            links.map(link => (
+              <li className="nhsuk-header__navigation-item">
+                <Link href={link.url}>
+                  <a className="nhsuk-header__navigation-link">{ link.label }</a>
+                </Link>
+              </li>
+            ))
+          }
+
+        </ul>
+      </div>
+    </nav>
+  );
+}

--- a/ui/components/Navigation/style.module.scss
+++ b/ui/components/Navigation/style.module.scss
@@ -1,0 +1,3 @@
+.navigation {
+
+}

--- a/ui/components/index.js
+++ b/ui/components/index.js
@@ -4,6 +4,7 @@ export { default as Card } from './Card';
 export { default as Dataset } from './Dataset';
 export { default as Details } from './Details';
 export { default as EmailSignup } from './EmailSignup';
+export { default as Expander } from './Expander';
 export { default as Feedback } from './Feedback';
 export { default as Flex } from './Flex';
 export { default as Filters } from './Filters';

--- a/ui/components/index.js
+++ b/ui/components/index.js
@@ -11,6 +11,7 @@ export { default as Filters } from './Filters';
 export { default as Hero } from './Hero';
 export { default as Link } from './Link';
 export { default as Model } from './Model';
+export { default as Navigation } from './Navigation';
 export { default as OptionSelect } from './OptionSelect';
 export { default as Page } from './Page';
 export { default as Pagination } from './Pagination';

--- a/ui/pages/index.js
+++ b/ui/pages/index.js
@@ -82,7 +82,7 @@ export default function Home() {
 
     <div className="nhsuk-grid-row">
       <div className="nhsuk-grid-column-one-third">
-        <h2><Link href="#">Upcoming standards</Link></h2>
+        <h2><Link href="/roadmap">Upcoming standards</Link></h2>
         <p>Stay up to date with standards and APIs that are being proposed or drafted by standard development bodies.</p>
       </div>
       <div className="nhsuk-grid-column-one-third">
@@ -90,7 +90,7 @@ export default function Home() {
         <p>Find out what information standards are and what interoperability means in health and social care.</p>
       </div>
       <div className="nhsuk-grid-column-one-third">
-        <h2><Link href="#">Community</Link></h2>
+        <h2><Link href="/community">Community</Link></h2>
         <p>Connect with other health and social care professionals and share knowledge and best practice.</p>
       </div>
     </div>

--- a/ui/pages/index.js
+++ b/ui/pages/index.js
@@ -57,14 +57,84 @@ const Section = (section, pages) => {
 };
 
 export default function Home({ pages }) {
-  const sections = [
-    ...new Set(pages.map((i) => i.homepage_section).filter((i) => i)),
-  ];
-  return pages ? (
-    <Page content={content} title={content.title}>
-      {sections.map((section) => Section(section, pages))}
-    </Page>
-  ) : null;
+  return <>
+    <div className="nhsuk-grid-row">
+      <div className="nhsuk-grid-column-full">
+        <h2>Browse by care setting</h2>
+      </div>
+      <div className="nhsuk-grid-column-one-third">
+        <h3><Link href="/standards?care_setting=Hospital">Hospital</Link></h3>
+        <p>Lorem ipsum dolor</p>
+      </div>
+      <div className="nhsuk-grid-column-one-third">
+        <h3><Link href="/standards?care_setting=GP+%2F+Primary+care">GP/Primary Care</Link></h3>
+        <p>Lorem ipsum dolor</p>
+      </div>
+      <div className="nhsuk-grid-column-one-third">
+        <h3><Link href="/standards?care_setting=Social+care">Social care</Link></h3>
+        <p>Lorem ipsum dolor</p>
+      </div>
+      <div className="nhsuk-grid-column-full">
+        <p><Link href="/standards">Browse all care settings</Link></p>
+      </div>
+    </div>
+    <div className="nhsuk-grid-row">
+      <div className="nhsuk-grid-column-full">
+        <h2>Browse by topic</h2>
+      </div>
+      <div className="nhsuk-grid-column-one-third">
+        <h3><Link href="#">Something</Link></h3>
+        <p>Lorem ipsum dolor</p>
+      </div>
+      <div className="nhsuk-grid-column-one-third">
+        <h3><Link href="#">Something</Link></h3>
+        <p>Lorem ipsum dolor</p>
+      </div>
+      <div className="nhsuk-grid-column-one-third">
+        <h3><Link href="#">Something</Link></h3>
+        <p>Lorem ipsum dolor</p>
+      </div>
+      <div className="nhsuk-grid-column-full">
+        <p><Link href="/standards">Browse all topics</Link></p>
+      </div>
+    </div>
+    <div className="nhsuk-grid-row">
+      <div className="nhsuk-grid-column-full">
+        <h2>Browse by type</h2>
+      </div>
+      <div className="nhsuk-grid-column-one-third">
+        <h3><Link href="#">Something</Link></h3>
+        <p>Lorem ipsum dolor</p>
+      </div>
+      <div className="nhsuk-grid-column-one-third">
+        <h3><Link href="#">Something</Link></h3>
+        <p>Lorem ipsum dolor</p>
+      </div>
+      <div className="nhsuk-grid-column-one-third">
+        <h3><Link href="#">Something</Link></h3>
+        <p>Lorem ipsum dolor</p>
+      </div>
+      <div className="nhsuk-grid-column-full">
+        <p><Link href="/standards">Browse all standard types</Link></p>
+      </div>
+    </div>
+
+    <div className="nhsuk-grid-row">
+      <div className="nhsuk-grid-column-one-third">
+        <h2><Link href="#">Roadmap</Link></h2>
+        <p>Lorem ipsum dolor</p>
+      </div>
+      <div className="nhsuk-grid-column-one-third">
+        <h2><Link href="/what-information-standards-are">Guidance</Link></h2>
+        <p>Lorem ipsum dolor</p>
+      </div>
+      <div className="nhsuk-grid-column-one-third">
+        <h2><Link href="#">Community</Link></h2>
+        <p>Lorem ipsum dolor</p>
+      </div>
+    </div>
+
+  </>
 }
 
 export function HomepageHero() {

--- a/ui/pages/index.js
+++ b/ui/pages/index.js
@@ -12,9 +12,9 @@ import React from 'react';
 const content = {
   title: 'Home - Standards Directory',
   header:
-    'Find standards and APIs to support data sharing in health and social care',
+    'Find standards for data and interoperability in health and social care',
   intro:
-    'Use this directory to find nationally recognised information standards and APIs needed to build interoperable technology.',
+    'Use this directory to find nationally recognised information standards for interoperable technology in health and adult social care.',
 };
 
 export default function Home() {
@@ -25,15 +25,15 @@ export default function Home() {
       </div>
       <div className="nhsuk-grid-column-one-third">
         <h3><Link href="/standards?care_setting=Hospital">Hospital</Link></h3>
-        <p>Lorem ipsum dolor</p>
+        <p>Patient services, maternity, assessments, discharge, accident and emergency care.</p>
       </div>
       <div className="nhsuk-grid-column-one-third">
-        <h3><Link href="/standards?care_setting=GP+%2F+Primary+care">GP/Primary Care</Link></h3>
-        <p>Lorem ipsum dolor</p>
+        <h3><Link href="/standards?care_setting=GP+%2F+Primary+care">GP / Primary Care</Link></h3>
+        <p>Physical and mental health, GP care records, diagnostics, clinical referrals, treatments.</p>
       </div>
       <div className="nhsuk-grid-column-one-third">
         <h3><Link href="/standards?care_setting=Social+care">Social care</Link></h3>
-        <p>Lorem ipsum dolor</p>
+        <p>Adult social care, social services, shared care records, community care and support.</p>
       </div>
       <div className="nhsuk-grid-column-full">
         <p><Link href="/standards">Browse all care settings</Link></p>
@@ -44,16 +44,16 @@ export default function Home() {
         <h2>Browse by topic</h2>
       </div>
       <div className="nhsuk-grid-column-one-third">
-        <h3><Link href="#">Something</Link></h3>
-        <p>Lorem ipsum dolor</p>
+        <h3><Link href="/standards?business_use=Appointment+%2F+scheduling">Appointments</Link></h3>
+        <p>Appointment booking and management, clinical referrals, key care information.</p>
       </div>
       <div className="nhsuk-grid-column-one-third">
-        <h3><Link href="#">Something</Link></h3>
-        <p>Lorem ipsum dolor</p>
+        <h3><Link href="/standards?business_use=Access+to+records">Access to records</Link></h3>
+        <p>Retrieve structured information from a patient's GP and shared care records.</p>
       </div>
       <div className="nhsuk-grid-column-one-third">
-        <h3><Link href="#">Something</Link></h3>
-        <p>Lorem ipsum dolor</p>
+        <h3><Link href="/standards?business_use=Vaccination">Vaccination</Link></h3>
+        <p>Coronavirus (COVID-19), seasonal flu, immunisation, treatment and prevention protocols.</p>
       </div>
       <div className="nhsuk-grid-column-full">
         <p><Link href="/standards">Browse all topics</Link></p>
@@ -64,16 +64,16 @@ export default function Home() {
         <h2>Browse by type</h2>
       </div>
       <div className="nhsuk-grid-column-one-third">
-        <h3><Link href="#">Something</Link></h3>
-        <p>Lorem ipsum dolor</p>
+        <h3><Link href="/standards?standard_category=Technical+standards+and+specifications">Technical specifications and APIs</Link></h3>
+        <p>Find technical standards to exchange information with other technology products and services.</p>
       </div>
       <div className="nhsuk-grid-column-one-third">
-        <h3><Link href="#">Something</Link></h3>
-        <p>Lorem ipsum dolor</p>
+        <h3><Link href="/standards?standard_category=Record+standard">Clinical and care record standards</Link></h3>
+        <p>Explore clinical codes and data formats to collect, process and share information consistently.</p>
       </div>
       <div className="nhsuk-grid-column-one-third">
-        <h3><Link href="#">Something</Link></h3>
-        <p>Lorem ipsum dolor</p>
+        <h3><Link href="/standards?standard_category=Data+definitions+and+terminologies">Medical and data dictionaries</Link></h3>
+        <p>Use approved medical terminologies and definitions to support information systems.</p>
       </div>
       <div className="nhsuk-grid-column-full">
         <p><Link href="/standards">Browse all standard types</Link></p>
@@ -83,15 +83,15 @@ export default function Home() {
     <div className="nhsuk-grid-row">
       <div className="nhsuk-grid-column-one-third">
         <h2><Link href="#">Roadmap</Link></h2>
-        <p>Lorem ipsum dolor</p>
+        <p>Stay up to date with standards and APIs that are being proposed or drafted by standard development bodies.</p>
       </div>
       <div className="nhsuk-grid-column-one-third">
         <h2><Link href="/what-information-standards-are">Guidance</Link></h2>
-        <p>Lorem ipsum dolor</p>
+        <p>Find out what information standards are and what interoperability means in health and social care.</p>
       </div>
       <div className="nhsuk-grid-column-one-third">
         <h2><Link href="#">Community</Link></h2>
-        <p>Lorem ipsum dolor</p>
+        <p>Connect with other health and social care professionals and share knowledge and best practice.</p>
       </div>
     </div>
 
@@ -107,10 +107,11 @@ export function HomepageHero({ recent }) {
             <Snippet inline>header</Snippet>
           </h1>
           <Snippet large>intro</Snippet>
+          <Search placeholder="For example, FHIR, allergies, GP" />
         </div>
         <div className="nhsuk-grid-column-one-third">
           <div className={styles.sidebar}>
-            <h2>New standards and APIs</h2>
+            <h2>Latest standards</h2>
             <ul>
               {
                 recent.map(standard => (
@@ -123,7 +124,7 @@ export function HomepageHero({ recent }) {
         </div>
       </div>
 
-      <Search placeholder="For example, FHIR, allergies, GP" />
+
     </Hero>
   );
 }

--- a/ui/pages/index.js
+++ b/ui/pages/index.js
@@ -113,7 +113,7 @@ export function HomepageHero({ recent }) {
             <h2>New standards and APIs</h2>
             <ul>
               {
-                recent.results.slice(0,3).map(standard => (
+                recent.map(standard => (
                   <li key={standard.id}><Link href={`/standards/${standard.name}`}>{ standard.title }</Link></li>
                 ))
               }
@@ -139,9 +139,10 @@ function HomeLayout({ children, ...props }) {
 Home.Layout = HomeLayout;
 
 export async function getServerSideProps() {
+  const recent = await list({ sort: { metadata_modified: 'desc' } });
   return {
     props: {
-      recent: await list({ sort: { metadata_modified: 'desc' } }),
+      recent: recent.results.slice(0, 3),
       content,
     },
   };

--- a/ui/pages/index.js
+++ b/ui/pages/index.js
@@ -49,7 +49,7 @@ export default function Home() {
       </div>
       <div className="nhsuk-grid-column-one-third">
         <h3><Link href="/standards?business_use=Access+to+records">Access to records</Link></h3>
-        <p>Retrieve structured information from a patient's GP and shared care records.</p>
+        <p>Retrieve structured information from a patient and shared care records.</p>
       </div>
       <div className="nhsuk-grid-column-one-third">
         <h3><Link href="/standards?business_use=Vaccination">Vaccination</Link></h3>

--- a/ui/pages/index.js
+++ b/ui/pages/index.js
@@ -6,7 +6,7 @@ import {
   Search,
 } from '../components';
 import styles from '../styles/Home.module.scss';
-import { getPages } from '../helpers/api';
+import { list } from '../helpers/api';
 import React from 'react';
 
 const content = {
@@ -98,7 +98,7 @@ export default function Home() {
   </>
 }
 
-export function HomepageHero() {
+export function HomepageHero({ recent }) {
   return (
     <Hero>
       <div className="nhsuk-grid-row">
@@ -112,9 +112,11 @@ export function HomepageHero() {
           <div className={styles.sidebar}>
             <h2>New standards and APIs</h2>
             <ul>
-              <li><Link href="#">Mental health inpatient discharge</Link></li>
-              <li><Link href="#">Transfer of care mental health discharge - FIHR</Link></li>
-              <li><Link href="#">SNOMED CT</Link></li>
+              {
+                recent.results.slice(0,3).map(standard => (
+                  <li key={standard.id}><Link href={`/standards/${standard.name}`}>{ standard.title }</Link></li>
+                ))
+              }
             </ul>
             <p><Link href="/standards">Browse the latest standards and APIs</Link></p>
           </div>
@@ -126,9 +128,9 @@ export function HomepageHero() {
   );
 }
 
-function HomeLayout({ children }) {
+function HomeLayout({ children, ...props }) {
   return (
-    <Layout Hero={HomepageHero} homepage hideSearch>
+    <Layout Hero={HomepageHero} {...props} homepage hideSearch>
       {children}
     </Layout>
   );
@@ -139,7 +141,7 @@ Home.Layout = HomeLayout;
 export async function getServerSideProps() {
   return {
     props: {
-      pages: await getPages(),
+      recent: await list({ sort: { metadata_modified: 'desc' } }),
       content,
     },
   };

--- a/ui/pages/index.js
+++ b/ui/pages/index.js
@@ -82,7 +82,7 @@ export default function Home() {
 
     <div className="nhsuk-grid-row">
       <div className="nhsuk-grid-column-one-third">
-        <h2><Link href="#">Roadmap</Link></h2>
+        <h2><Link href="#">Upcoming standards</Link></h2>
         <p>Stay up to date with standards and APIs that are being proposed or drafted by standard development bodies.</p>
       </div>
       <div className="nhsuk-grid-column-one-third">

--- a/ui/pages/index.js
+++ b/ui/pages/index.js
@@ -2,12 +2,8 @@ import Link from 'next/link';
 import {
   Hero,
   Layout,
-  Page,
   Snippet,
   Search,
-  Row,
-  Col,
-  Card,
 } from '../components';
 import styles from '../styles/Home.module.scss';
 import { getPages } from '../helpers/api';
@@ -21,42 +17,7 @@ const content = {
     'Use this directory to find nationally recognised information standards and APIs needed to build interoperable technology.',
 };
 
-const Section = (section, pages) => {
-  const items = pages.filter((i) => i.homepage_section === section);
-  return (
-    <React.Fragment key={section}>
-      <h3>{section}</h3>
-      <Row>
-        {items.map((pageItem, index) => {
-          const {
-            name,
-            title,
-            short_title: shortTitle,
-            homepage_snippet: snippet,
-            add_to_home_page: addToHomepage,
-          } = pageItem;
-          if (!addToHomepage) {
-            return null;
-          }
-          return (
-            <Col key={index}>
-              <Link href={`/${name}`}>
-                <a>
-                  <Card clickable className={styles.card}>
-                    <h5>{shortTitle || title}</h5>
-                    <p className="nhsuk-body-s">{snippet}</p>
-                  </Card>
-                </a>
-              </Link>
-            </Col>
-          );
-        })}
-      </Row>
-    </React.Fragment>
-  );
-};
-
-export default function Home({ pages }) {
+export default function Home() {
   return <>
     <div className="nhsuk-grid-row">
       <div className="nhsuk-grid-column-full">

--- a/ui/pages/index.js
+++ b/ui/pages/index.js
@@ -78,6 +78,15 @@ export function HomepageHero() {
           <Snippet large>intro</Snippet>
         </div>
         <div className="nhsuk-grid-column-one-third">
+          <div className={styles.sidebar}>
+            <h2>New standards and APIs</h2>
+            <ul>
+              <li><Link href="#">Mental health inpatient discharge</Link></li>
+              <li><Link href="#">Transfer of care mental health discharge - FIHR</Link></li>
+              <li><Link href="#">SNOMED CT</Link></li>
+            </ul>
+            <p><Link href="/standards">Browse the latest standards and APIs</Link></p>
+          </div>
         </div>
       </div>
 

--- a/ui/pages/index.js
+++ b/ui/pages/index.js
@@ -24,15 +24,15 @@ export default function Home() {
         <h2>Browse by care setting</h2>
       </div>
       <div className="nhsuk-grid-column-one-third">
-        <h3><Link href="/standards?care_setting=Hospital">Hospital</Link></h3>
+        <h5><Link href="/standards?care_setting=Hospital">Hospital</Link></h5>
         <p>Patient services, maternity, assessments, discharge, accident and emergency care.</p>
       </div>
       <div className="nhsuk-grid-column-one-third">
-        <h3><Link href="/standards?care_setting=GP+%2F+Primary+care">GP / Primary Care</Link></h3>
+        <h5><Link href="/standards?care_setting=GP+%2F+Primary+care">GP / Primary Care</Link></h5>
         <p>Physical and mental health, GP care records, diagnostics, clinical referrals, treatments.</p>
       </div>
       <div className="nhsuk-grid-column-one-third">
-        <h3><Link href="/standards?care_setting=Social+care">Social care</Link></h3>
+        <h5><Link href="/standards?care_setting=Social+care">Social care</Link></h5>
         <p>Adult social care, social services, shared care records, community care and support.</p>
       </div>
       <div className="nhsuk-grid-column-full">
@@ -44,15 +44,15 @@ export default function Home() {
         <h2>Browse by topic</h2>
       </div>
       <div className="nhsuk-grid-column-one-third">
-        <h3><Link href="/standards?business_use=Appointment+%2F+scheduling">Appointments</Link></h3>
+        <h5><Link href="/standards?business_use=Appointment+%2F+scheduling">Appointments</Link></h5>
         <p>Appointment booking and management, clinical referrals, key care information.</p>
       </div>
       <div className="nhsuk-grid-column-one-third">
-        <h3><Link href="/standards?business_use=Access+to+records">Access to records</Link></h3>
+        <h5><Link href="/standards?business_use=Access+to+records">Access to records</Link></h5>
         <p>Retrieve structured information from a patient and shared care records.</p>
       </div>
       <div className="nhsuk-grid-column-one-third">
-        <h3><Link href="/standards?business_use=Vaccination">Vaccination</Link></h3>
+        <h5><Link href="/standards?business_use=Vaccination">Vaccination</Link></h5>
         <p>Coronavirus (COVID-19), seasonal flu, immunisation, treatment and prevention protocols.</p>
       </div>
       <div className="nhsuk-grid-column-full">
@@ -64,15 +64,15 @@ export default function Home() {
         <h2>Browse by type</h2>
       </div>
       <div className="nhsuk-grid-column-one-third">
-        <h3><Link href="/standards?standard_category=Technical+standards+and+specifications">Technical specifications and APIs</Link></h3>
+        <h5><Link href="/standards?standard_category=Technical+standards+and+specifications">Technical specifications and APIs</Link></h5>
         <p>Find technical standards to exchange information with other technology products and services.</p>
       </div>
       <div className="nhsuk-grid-column-one-third">
-        <h3><Link href="/standards?standard_category=Record+standard">Clinical and care record standards</Link></h3>
+        <h5><Link href="/standards?standard_category=Record+standard">Clinical and care record standards</Link></h5>
         <p>Explore clinical codes and data formats to collect, process and share information consistently.</p>
       </div>
       <div className="nhsuk-grid-column-one-third">
-        <h3><Link href="/standards?standard_category=Data+definitions+and+terminologies">Medical and data dictionaries</Link></h3>
+        <h5><Link href="/standards?standard_category=Data+definitions+and+terminologies">Medical and data dictionaries</Link></h5>
         <p>Use approved medical terminologies and definitions to support information systems.</p>
       </div>
       <div className="nhsuk-grid-column-full">
@@ -82,16 +82,19 @@ export default function Home() {
 
     <div className="nhsuk-grid-row">
       <div className="nhsuk-grid-column-one-third">
-        <h2><Link href="/roadmap">Upcoming standards</Link></h2>
+        <h2>Upcoming standards</h2>
         <p>Stay up to date with standards and APIs that are being proposed or drafted by standard development bodies.</p>
+        <p><Link href="/roadmap">Search the roadmap</Link></p>
       </div>
       <div className="nhsuk-grid-column-one-third">
-        <h2><Link href="/what-information-standards-are">Guidance</Link></h2>
+        <h2>Guidance</h2>
         <p>Find out what information standards are and what interoperability means in health and social care.</p>
+        <p><Link href="/what-information-standards-are">Learn more</Link></p>
       </div>
       <div className="nhsuk-grid-column-one-third">
-        <h2><Link href="/community">Community</Link></h2>
+        <h2>Community</h2>
         <p>Connect with other health and social care professionals and share knowledge and best practice.</p>
+        <p><Link href="/community">View the community resources</Link></p>
       </div>
     </div>
 

--- a/ui/pages/standards/[id].js
+++ b/ui/pages/standards/[id].js
@@ -5,7 +5,6 @@ import {
   Col,
   Model,
   ReviewDates,
-  FeedbackFooter,
 } from '../../components';
 
 import { read } from '../../helpers/api';
@@ -23,7 +22,6 @@ const Id = ({ data }) => {
       <Row>
         <Col className="nhsuk-grid-column-two-thirds">
           <Model schema={schema} data={data} />
-          <FeedbackFooter />
           <ReviewDates data={data} />
         </Col>
       </Row>

--- a/ui/pages/standards/index.js
+++ b/ui/pages/standards/index.js
@@ -6,7 +6,6 @@ import {
   Col,
   Filters,
   Dataset,
-  FeedbackFooter,
 } from '../../components';
 import { getPageProps } from '../../helpers/getPageProps';
 
@@ -27,7 +26,6 @@ export default function Standards({ data, schemaData }) {
         </Col>
         <Col colspan={3}>
           <Dataset data={data} pagination={true} />
-          <FeedbackFooter />
         </Col>
       </Row>
     </Page>

--- a/ui/schema/index.js
+++ b/ui/schema/index.js
@@ -81,26 +81,26 @@ export default [
     },
   },
   {
-    section_title: 'Business and care setting usage',
+    section_title: 'Topic and care setting usage',
     business_use: {
-      label: 'Business use',
+      label: 'Topic',
       format: (val) => val || 'As yet unspecified',
     },
     care_setting: {
-      label: 'Care Setting',
+      label: 'Care setting',
       format: (val) => val || 'As yet unspecified',
     },
   },
   {
     section_title: 'Relationships to other standards',
-    related_standards: {
-      label: 'Related standards',
+    dependencies: {
+      label: 'Dependencies',
       format: (val) =>
         (!!val?.length && <MarkdownBlock md={val} />) ||
         'Information unavailable',
     },
-    dependencies: {
-      label: 'Dependencies',
+    related_standards: {
+      label: 'Related standards',
       format: (val) =>
         (!!val?.length && <MarkdownBlock md={val} />) ||
         'Information unavailable',
@@ -109,11 +109,11 @@ export default [
   {
     section_title: 'Assurance and endorsements',
     reference_code: {
-      label: 'Reference Code',
-      format: (val) => val || 'Not Applicable',
+      label: 'Reference code for legally mandated standards',
+      format: (val) => val || 'None - not legally mandated',
     },
     assurance: {
-      label: 'Assurance',
+      label: 'Quality assured',
       format: (val) =>
         (!!val?.length && <MarkdownBlock md={val} />) || 'Not applicable',
     },

--- a/ui/schema/index.js
+++ b/ui/schema/index.js
@@ -44,6 +44,44 @@ export default [
     },
     standard_category: {
       label: 'Type of standard',
+      format: (val) => (
+        <>
+          <Tag status={val.toLowerCase()}>{upperFirst(val)}</Tag>
+          {
+            <Details
+              className="nhsuk-u-font-size-16 nhsuk-u-margin-top-4"
+              summary="What this type means"
+            >
+              <div className="nhsuk-details__text">
+                <Paragraph>
+                  <strong>Technical specifications and APIs</strong> specify how
+                  information is to be made available technically. This includes
+                  how the data is structured and transported, its architecture
+                  and associated protocols.
+                </Paragraph>
+                <Paragraph>
+                  <strong>Clinical and care record standards</strong> define what
+                  information to collect, the purpose of the information and how
+                  to format it for consistency of meaning - for example creating
+                  a standardised way to register a new patient.
+                </Paragraph>
+                <Paragraph>
+                  <strong>Medical and data dictionaries</strong> define the format
+                  of specific data items in ways that allow them to be consistently
+                  represented. Labelling of medicines or formatting of dates of
+                  birth are examples. This category also includes reference sets
+                  and controlled lists.
+                </Paragraph>
+                <Paragraph>
+                  <strong>Data protection and governance</strong> define rules
+                  for what information can be legally processed and how that
+                  information should be securely handled.
+                </Paragraph>
+              </div>
+            </Details>
+          }
+        </>
+      ),
     },
     documentation_help_text: {
       label: 'Documentation',

--- a/ui/styles/Home.module.scss
+++ b/ui/styles/Home.module.scss
@@ -4,6 +4,14 @@
   margin-bottom: $nhsuk-gutter * 2;
 }
 
+.sidebar {
+  border: 1px solid white;
+  padding: 2em 2em 1em;
+  a {
+    color: white;
+  }
+}
+
 .card {
   a {
     text-decoration: none !important;


### PR DESCRIPTION
The details component is now featured against the standard type. 

This is the first pass. The suggestion from the team was to have the relevant type description display against that listing and information to link and view other types in the guidance section.  If other high priority tasks need to be done first, then this can be considered for later/low priority.
<img width="761" alt="Screenshot 2022-04-05 at 13 13 09" src="https://user-images.githubusercontent.com/13965310/161753296-bfffc524-2c04-4727-b6bb-e5f7f1eea67c.png">

