### PR TITLE
[STAN-488] Change Business Use to Topic

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,7 @@ jobs:
           - 16.x
     env:
       PORT: 3000
-      CKAN_URL: https://manage.test.nhs.marvell-consulting.com/api/3/action
+      CKAN_URL: https://manage.dev.nhs.marvell-consulting.com/api/3/action
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,7 @@ jobs:
           - 16.x
     env:
       PORT: 3000
-      CKAN_URL: https://manage.dev.nhs.marvell-consulting.com/api/3/action
+      CKAN_URL: https://manage.test.nhs.marvell-consulting.com/api/3/action
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/ui/components/Filters/index.js
+++ b/ui/components/Filters/index.js
@@ -28,12 +28,7 @@ const pick = (names, fields) =>
 export default function Filters({ schema }) {
   const { dataset_fields: fields } = schema;
   const { getSelections, updateQuery } = useQueryContext();
-  const categories = [
-    'business_use',
-    'care_setting',
-    'standard_category',
-    'status',
-  ];
+  const categories = ['topic', 'care_setting', 'standard_category', 'status'];
   const filters = pick(categories, fields);
 
   const addFilter = (filter) => {
@@ -94,9 +89,9 @@ export default function Filters({ schema }) {
       <h3>Filters</h3>
       <PanelList>
         <div className="nhsuk-expander-group">
-        {filters.map((filter, index) => (
-          <Filter key={index} {...filter} onChange={setItem} />
-        ))}
+          {filters.map((filter, index) => (
+            <Filter key={index} {...filter} onChange={setItem} />
+          ))}
         </div>
       </PanelList>
     </div>

--- a/ui/pages/index.js
+++ b/ui/pages/index.js
@@ -88,7 +88,7 @@ export default function Home() {
       >
         <div className="nhsuk-grid-column-one-third">
           <h5>
-            <Link href="/standards?business_use=Appointment+%2F+scheduling">
+            <Link href="/standards?topic=Appointment+%2F+scheduling">
               Appointments
             </Link>
           </h5>
@@ -99,7 +99,7 @@ export default function Home() {
         </div>
         <div className="nhsuk-grid-column-one-third">
           <h5>
-            <Link href="/standards?business_use=Access+to+records">
+            <Link href="/standards?topic=Access+to+records">
               Access to records
             </Link>
           </h5>
@@ -110,7 +110,7 @@ export default function Home() {
         </div>
         <div className="nhsuk-grid-column-one-third">
           <h5>
-            <Link href="/standards?business_use=Vaccination">Vaccination</Link>
+            <Link href="/standards?topic=Vaccination">Vaccination</Link>
           </h5>
           <p>
             Coronavirus (COVID-19), seasonal flu, immunisation, treatment and

--- a/ui/schema/index.js
+++ b/ui/schema/index.js
@@ -82,7 +82,7 @@ export default [
   },
   {
     section_title: 'Topic and care setting usage',
-    business_use: {
+    topic: {
       label: 'Topic',
       format: (val) => val || 'As yet unspecified',
     },

--- a/ui/test/specs/standards/list.js
+++ b/ui/test/specs/standards/list.js
@@ -1,8 +1,8 @@
-describe('Homepage', () => {
-  it('should accesss the homepage', async () => {
+describe('Standards Listing Index', () => {
+  it('should accesss standards listing page', async () => {
     await browser.url(`/standards`);
 
-    await expect($('h1=Browse the standards directory')).toExist();
     await expect($('ul')).toExist();
+    await expect($('h1=Browse the standards directory')).toExist();
   });
 });

--- a/ui/wdio.conf.js
+++ b/ui/wdio.conf.js
@@ -227,6 +227,7 @@ exports.config = {
     // take a screenshot anytime a test fails and throws an error
     if (error) {
       browser.takeScreenshot();
+      console.log(test, context);
     }
   },
 

--- a/ui/wdio.conf.js
+++ b/ui/wdio.conf.js
@@ -223,6 +223,12 @@ exports.config = {
    */
   // afterTest: function(test, context, { error, result, duration, passed, retries }) {
   // },
+  afterTest: function (test, context, { error }) {
+    // take a screenshot anytime a test fails and throws an error
+    if (error) {
+      browser.takeScreenshot();
+    }
+  },
 
   /**
    * Hook that gets executed after the suite has ended


### PR DESCRIPTION
We've updated the schema to show `Topic` instead of `Business Use` [here](https://github.com/Marvell-Consulting/ckanext-scheming/commit/2a433a23fe3c6f37fd1964f017767483b3ae8bb0) 
Now we can respond to it in the frontend


<img width="756" alt="Screenshot 2022-04-05 at 16 11 15" src="https://user-images.githubusercontent.com/120181/161773589-0b65922f-caf4-4d5f-9097-ba79f352fe92.png">

<img width="354" alt="Screenshot 2022-04-05 at 16 11 01" src="https://user-images.githubusercontent.com/120181/161773599-91493dc4-41d2-4af9-84bf-34d48e6f4c69.png">

