### PR TITLE
Add sort menu to standards listing

### DIFF
--- a/ui/components/Dataset/index.js
+++ b/ui/components/Dataset/index.js
@@ -35,10 +35,55 @@ function Model({ model }) {
   );
 }
 
+function SortMenu({ searchTerm }) {
+  const { getSelections, updateQuery } = useQueryContext();
+
+  const sort = event => {
+    const selections = getSelections();
+    selections.sort = event.target.value;
+    updateQuery(selections, { replace: true });
+  };
+
+  const options = [
+    searchTerm && {
+      label: 'Relevance',
+      value: 'score desc'
+    },
+    {
+      label: 'Updated (newest)',
+      value: 'metadata_modified desc'
+    },
+    {
+      label: 'Updated (oldest)',
+      value: 'metadata_modified asc'
+    },
+    {
+      label: 'A-Z',
+      value: 'name asc'
+    },
+    {
+      label: 'Z-A',
+      value: 'name desc'
+    }
+  ];
+
+  const { sort: value } = getSelections();
+
+  return <div className="nhsuk-form-group">
+    <label className="nhsuk-label" htmlFor="sort">Sort by</label>
+    <select  className="nhsuk-select" name="sort" id="sort" onChange={sort}>
+      {
+        options.filter(Boolean).map(option => <option value={option.value} key={option.value} selected={option.value === value}>{ option.label }</option>)
+      }
+    </select>
+  </div>;
+}
+
 export default function Dataset({ data = {}, searchTerm, includeType }) {
   const { getSelections } = useQueryContext();
   const { count = 0, results = [] } = data;
   const filtersSelected = Object.keys(getSelections).length > 0;
+
 
   return (
     <>
@@ -52,6 +97,7 @@ export default function Dataset({ data = {}, searchTerm, includeType }) {
           {searchTerm || filtersSelected ? 'filters.summary' : 'filters.all'}
         </Snippet>
       </h3>
+      <SortMenu searchTerm={searchTerm} />
       <ul className={styles.list}>
         {results.map((model) => (
           <li key={model.id} className={styles.listItem}>

--- a/ui/context/query.js
+++ b/ui/context/query.js
@@ -16,8 +16,13 @@ export function QueryContextWrapper({ children }) {
     return router.query;
   }
 
-  function updateQuery(props) {
+  function updateQuery(props, { replace } = {}) {
     const { query } = router;
+    if (replace) {
+      return router.replace({ query: { ...query, ...props } }, null, {
+        scroll: false,
+      });
+    }
     return router.push({ query: { ...query, ...props } }, null, {
       scroll: false,
     });

--- a/ui/helpers/api.js
+++ b/ui/helpers/api.js
@@ -58,9 +58,13 @@ export async function list({ page = 1, q, sort, filters }) {
   // e.g.
   // sort=score desc, metadata_modified desc
   if (sort) {
-    sortstring = Object.entries(sort)
-      .map((i) => i.join(' '))
-      .join(', ');
+    if (typeof sort === 'string') {
+      sortstring = sort;
+    } else {
+      sortstring = Object.entries(sort)
+        .map((i) => i.join(' '))
+        .join(', ');
+    }
   }
 
   fq = serialise(queriseSelections(filters));


### PR DESCRIPTION
Supports sorting the list of all standards by best search match, last updated timestamp, or name. Including:

* Add option to not create new history entry when sorting
* If there's a `sort` value defined in the query string as a string then don't try to manipulate an object to a string
* Only show `Relevance` as a sort option if there's a search term defined