### PR TITLE
Add alerting into Slack for build statuses

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -50,7 +50,7 @@ jobs:
 
   notify:
     runs-on: ubuntu-latest
-    if: ${{ always() }}
+    if: ${{ failure() }}
     needs:
       - test
       - integrationtest
@@ -62,4 +62,4 @@ jobs:
           SLACK_CHANNEL: developers
           SLACK_COLOR: ${{ job.status }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_TITLE: "build: ${{job.status}}"
+          SLACK_TITLE: Build failed

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -47,3 +47,19 @@ jobs:
       - run: npm run build --if-present
       - run: npm start &
       - run: npm run test:integration
+
+  notify:
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs:
+      - test
+      - integrationtest
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_USERNAME: github-bot
+          SLACK_CHANNEL: developers
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_TITLE: "build: ${{job.status}}"

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -61,6 +61,7 @@ jobs:
             --set ui.config.ckanurl='${{ secrets.CKAN_URL }}'
             --set ui.config.tracking_id='${{ secrets.TRACKING_ID }}'
             --set ui.container.image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
   ckan:
     runs-on: ubuntu-latest
     environment: dev
@@ -119,3 +120,19 @@ jobs:
             --set image.tag=$IMAGE_TAG
             --set ckan.psql.initialize=false
             --set solr.initialize.enabled=false
+  notify:
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs:
+      - ui
+      - ckan
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_USERNAME: github-bot
+          SLACK_CHANNEL: developers
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_TITLE: "dev deployment: ${{job.status}}"
+          MSG_MINIMAL: "true"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -119,3 +119,19 @@ jobs:
             --set postgresql.enabled=false
             --set ckan.psql.initialize=false
             --set solr.initialize.enabled=false
+  notify:
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs:
+      - ui
+      - ckan
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_USERNAME: github-bot
+          SLACK_CHANNEL: developers
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_TITLE: "prod deployment: ${{job.status}}"
+          MSG_MINIMAL: "true"

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -118,3 +118,20 @@ jobs:
             --set image.tag=$IMAGE_TAG
             --set ckan.psql.initialize=false
             --set solr.initialize.enabled=false
+
+  notify:
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs:
+      - ui
+      - ckan
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_USERNAME: github-bot
+          SLACK_CHANNEL: developers
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_TITLE: "test deployment: ${{job.status}}"
+          MSG_MINIMAL: "true"


### PR DESCRIPTION
Sends a slack message to #developers when a PR build fails or on any complete deployment irrespective of status.