### PR TITLE
Return a 404 page for pages which don't exist

### DIFF
--- a/ui/pages/[page].js
+++ b/ui/pages/[page].js
@@ -21,6 +21,12 @@ export async function getServerSideProps(context) {
   const pages = await getPages();
   const pageData = pages.filter((i) => i.name === page).pop();
 
+  if (!pageData) {
+    return {
+      notFound: true
+    };
+  }
+
   return {
     props: {
       pageData,


### PR DESCRIPTION
Instead of throwing a 500 error about `pageData` not being serialisable as JSON, instead return a 404.