### PR TITLE
[STAN-491] Add large search bar to directory pages

### DIFF
--- a/ui/components/Layout/index.js
+++ b/ui/components/Layout/index.js
@@ -72,8 +72,8 @@ export default function Home({ children, ...props }) {
               </div>
             </Col>
             <Col>
-              {!props.hideSearch && (
-                <Search label={false} placeholder="Search" />
+              {!props.hideBannerSearch && (
+                <Search label={false} placeholder="Search" location="nav" />
               )}
             </Col>
           </Row>

--- a/ui/components/Search/index.js
+++ b/ui/components/Search/index.js
@@ -3,38 +3,57 @@ import classnames from 'classnames';
 import { useQueryContext } from '../../context/query';
 import styles from './style.module.scss';
 
-export default function Search({ placeholder, label = true }) {
+export default function Search({
+  placeholder,
+  label = true,
+  labelText = 'Search directory',
+  location = null,
+}) {
   const { query } = useQueryContext();
   const [value, setValue] = useState(query.q);
   return (
-    <form
-      className={classnames('nhsuk-search', styles.search)}
-      method="GET"
-      action="/search-results"
-    >
-      {label && <label className="nhsuk-label">Search directory</label>}
-      <input
-        type="text"
-        className={classnames('nhsuk-input', styles.input)}
-        placeholder={placeholder}
-        name="q"
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-      />
-      <button className={classnames('nhsuk-search__submit', styles.button)}>
-        <svg
+    <div className="nhsuk-form-group">
+      <form
+        className={classnames('nhsuk-search', styles.search)}
+        method="GET"
+        action="/search-results"
+      >
+        {label && <label className="nhsuk-label">{labelText}</label>}
+        <input
+          type="text"
           className={classnames(
-            'nhsuk-icon nhsuk-icon__search nhsuk-u-font-size-16',
-            styles.icon
+            'nhsuk-input',
+            location === 'browse' ? styles.inputBrowse : styles.input
           )}
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          aria-hidden="true"
-          focusable="false"
-        >
-          <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
-        </svg>
-      </button>
-    </form>
+          placeholder={placeholder}
+          name="q"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+        />
+
+        {location === 'nav' ? (
+          <button className={classnames('nhsuk-search__submit', styles.button)}>
+            <svg
+              className={classnames(
+                'nhsuk-icon nhsuk-icon__search nhsuk-u-font-size-16',
+                styles.icon
+              )}
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
+            </svg>
+          </button>
+        ) : (
+          <button
+            className={classnames('nhsuk-search__submit', styles.buttonText)}
+          >
+            <span className="hod-search side-space icon-small">Search</span>
+          </button>
+        )}
+      </form>
+    </div>
   );
 }

--- a/ui/components/Search/index.js
+++ b/ui/components/Search/index.js
@@ -3,6 +3,27 @@ import classnames from 'classnames';
 import { useQueryContext } from '../../context/query';
 import styles from './style.module.scss';
 
+const SearchIcon = () => (
+  <svg
+    className={classnames(
+      'nhsuk-icon nhsuk-icon__search nhsuk-u-font-size-16',
+      styles.icon
+    )}
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
+  </svg>
+);
+
+const SearchButton = ({ style, children }) => (
+  <button className={classnames('nhsuk-search__submit', style)}>
+    {children}
+  </button>
+);
+
 export default function Search({
   placeholder,
   label = true,
@@ -32,26 +53,11 @@ export default function Search({
         />
 
         {location === 'nav' ? (
-          <button className={classnames('nhsuk-search__submit', styles.button)}>
-            <svg
-              className={classnames(
-                'nhsuk-icon nhsuk-icon__search nhsuk-u-font-size-16',
-                styles.icon
-              )}
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-              focusable="false"
-            >
-              <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
-            </svg>
-          </button>
+          <SearchButton style={styles.button}>
+            <SearchIcon />
+          </SearchButton>
         ) : (
-          <button
-            className={classnames('nhsuk-search__submit', styles.buttonText)}
-          >
-            <span className="hod-search side-space icon-small">Search</span>
-          </button>
+          <SearchButton style={styles.buttonText}>Search</SearchButton>
         )}
       </form>
     </div>

--- a/ui/components/Search/style.module.scss
+++ b/ui/components/Search/style.module.scss
@@ -8,8 +8,32 @@
 .input {
   padding-left: 0.5em;
   border: none;
-  border-radius: 4px;
   background-color: $color_nhsuk-grey-5;
+}
+.inputBrowse {
+}
+.buttonBrowse {
+}
+
+.buttonText {
+  position: absolute;
+  color: white;
+  background-color: black;
+  right: 0;
+  bottom: 0;
+  border-radius: 0;
+  height: auto;
+  width: auto;
+  padding: 8px;
+  &:hover {
+    border: none;
+    background-color: $color_nhsuk-grey-1;
+  }
+  &:active,
+  &:focus {
+    outline: 0px;
+    color: white;
+  }
 }
 
 .button {

--- a/ui/components/Search/style.module.scss
+++ b/ui/components/Search/style.module.scss
@@ -10,10 +10,6 @@
   border: none;
   background-color: $color_nhsuk-grey-5;
 }
-.inputBrowse {
-}
-.buttonBrowse {
-}
 
 .buttonText {
   position: absolute;

--- a/ui/pages/index.js
+++ b/ui/pages/index.js
@@ -222,7 +222,7 @@ export function HomepageHero({ recent }) {
 
 function HomeLayout({ children, ...props }) {
   return (
-    <Layout Hero={HomepageHero} {...props} homepage hideSearch>
+    <Layout Hero={HomepageHero} {...props} homepage hideBannerSearch>
       {children}
     </Layout>
   );

--- a/ui/pages/search-results.js
+++ b/ui/pages/search-results.js
@@ -1,4 +1,6 @@
 import {
+  Search,
+  Layout,
   Page,
   Col,
   Row,
@@ -26,6 +28,15 @@ export default function SearchResults({ data, searchTerm, schemaData }) {
       <Reading>
         <Snippet>intro</Snippet>
       </Reading>
+      <div className="nhsuk-grid-row">
+        <div className="nhsuk-grid-column-three-quarters">
+          <Search
+            labelText="Find a standard"
+            placeholder="For example, FHIR, allergies, GP"
+            location="browse"
+          />
+        </div>
+      </div>
       <Row>
         <Col>
           <Filters schema={schemaData} />
@@ -37,6 +48,10 @@ export default function SearchResults({ data, searchTerm, schemaData }) {
     </Page>
   );
 }
+
+SearchResults.Layout = function SearchResults({ children }) {
+  return <Layout hideBannerSearch>{children}</Layout>;
+};
 
 export async function getServerSideProps(context) {
   return await getPageProps(context, { content });

--- a/ui/pages/standards/index.js
+++ b/ui/pages/standards/index.js
@@ -1,6 +1,8 @@
 import {
+  Layout,
   Reading,
   Snippet,
+  Search,
   Page,
   Row,
   Col,
@@ -20,6 +22,15 @@ export default function Standards({ data, schemaData }) {
           health and social care.
         </p>
       </Reading>
+      <div className="nhsuk-grid-row">
+        <div className="nhsuk-grid-column-three-quarters">
+          <Search
+            labelText="Find a standard"
+            placeholder="For example, FHIR, allergies, GP"
+            location="browse"
+          />
+        </div>
+      </div>
       <Row>
         <Col>
           <Filters schema={schemaData} />
@@ -31,6 +42,10 @@ export default function Standards({ data, schemaData }) {
     </Page>
   );
 }
+
+Standards.Layout = function StandardsLayout({ children }) {
+  return <Layout hideBannerSearch>{children}</Layout>;
+};
 
 export async function getServerSideProps(context) {
   return await getPageProps(context);


### PR DESCRIPTION
[Adds "location" to search for styling in context](https://github.com/nhsx/standards-registry/commit/e5433c93c7a807ea533b02bb52c29076dc87c2a9)

* `location` can now be passed to `Search`
* means it works in its different contexts (Home, Directory, and Navigation bar)
* Rough and ready swapping between "Search" button and Icon button
* Lots of `Layout` wrangling to remove search from nav when it's rendered
lower in the page, which I'm not thrilled with, but seems the way for now

**Browse Context**
<img width="1010" alt="Screenshot 2022-04-07 at 11 07 50" src="https://user-images.githubusercontent.com/120181/162171873-0f9f0ecb-29de-4ae6-8f36-d199194171e5.png">

**Nav context**
<img width="986" alt="Screenshot 2022-04-07 at 11 08 00" src="https://user-images.githubusercontent.com/120181/162171906-833c7396-a5f9-4603-97a9-0fc6fab2dca2.png">

**Homepage @mobile**
<img width="484" alt="Screenshot 2022-04-07 at 11 08 32" src="https://user-images.githubusercontent.com/120181/162171982-8d83284a-5cdc-4169-af8e-8de5b625d102.png">

**Homepage**
<img width="1056" alt="Screenshot 2022-04-07 at 11 49 07" src="https://user-images.githubusercontent.com/120181/162172053-118f1f29-eef1-434a-960c-db25211e0d98.png">

