### PR TITLE
STAN-496 standard type tags

### DIFF
--- a/ui/components/Tag/index.js
+++ b/ui/components/Tag/index.js
@@ -1,16 +1,16 @@
 import classnames from 'classnames';
 
-const statusMap = {
-  active: 'nhsuk-tag--blue',
-  draft: 'nhsuk-tag--grey',
-  deprecated: 'nhsuk-tag--orange',
-  retired: 'nhsuk-tag--red',
+const typeMap = {
+  technical: 'nhsuk-tag--blue',
+  governance: 'nhsuk-tag--grey',
+  clinical: 'nhsuk-tag--orange',
+  dictioary: 'nhsuk-tag--green',
 };
 
-export default function Tag({ children, classes, status }) {
+export default function Tag({ children, classes, type }) {
   return (
     <span
-      className={classnames('nhsuk-tag', classes, statusMap[status] || null)}
+      className={classnames('nhsuk-tag', classes, typeMap[type] || null)}
     >
       {children}
     </span>

--- a/ui/components/Tag/index.js
+++ b/ui/components/Tag/index.js
@@ -1,13 +1,13 @@
 import classnames from 'classnames';
 
 const typeMap = {
-  technical: 'nhsuk-tag--blue',
-  governance: 'nhsuk-tag--grey',
-  clinical: 'nhsuk-tag--orange',
-  dictioary: 'nhsuk-tag--green',
+  'Technical specifications and APIs': 'nhsuk-tag--blue',
+  'Data governance and information': 'nhsuk-tag--grey',
+  'Clinical and care record standards': 'nhsuk-tag--orange',
+  'Medical data and dictionaries': 'nhsuk-tag--green',
 };
 
-export default function Tag({ children, classes, type }) {
+export default function TypeTag({ children, classes, type }) {
   return (
     <span
       className={classnames('nhsuk-tag', classes, typeMap[type] || null)}

--- a/ui/helpers/api.js
+++ b/ui/helpers/api.js
@@ -2,6 +2,13 @@ import fetch from 'node-fetch';
 import { stringify } from 'qs';
 const CKAN_URL = process.env.CKAN_URL;
 
+const typeMap = {
+  'Technical standards and specifications': 'Technical specifications and APIs',
+  'Record standard': 'Clinical and care record standards',
+  'Data definitions and terminologies': 'Medical data and dictionaries',
+  'Information code of practice and governance standard': 'Data governance and information'
+};
+
 // TODO: neaten
 export function queriseSelections(selections) {
   const selectionsRef = { ...selections };
@@ -41,6 +48,9 @@ export function serialise(obj = {}) {
 export async function read({ id }) {
   const response = await fetch(`${CKAN_URL}/package_show?id=${id}`);
   const data = await response.json();
+  if (typeMap[data.result.standard_category]) {
+    data.result.standard_category = typeMap[data.result.standard_category];
+  }
   return data.result;
 }
 
@@ -82,6 +92,18 @@ export async function schema(dataset = 'dataset') {
     `${CKAN_URL}/scheming_dataset_schema_show?type=${dataset}`
   );
   const data = await response.json();
+
+
+
+  const category = data.result.dataset_fields.find(field => field.field_name === 'standard_category');
+  if (category) {
+    category.choices.forEach(choice => {
+      if (typeMap[choice.value]) {
+        choice.label = typeMap[choice.value];
+      }
+    });
+  }
+
   return data.result;
 }
 

--- a/ui/schema/index.js
+++ b/ui/schema/index.js
@@ -46,7 +46,7 @@ export default [
       label: 'Type of standard',
       format: (val) => (
         <>
-          <Tag type={val.toLowerCase()}>{upperFirst(val)}</Tag>
+          <Tag type={val}>{val}</Tag>
           {
             <Details
               className="nhsuk-u-font-size-16 nhsuk-u-margin-top-4"

--- a/ui/schema/index.js
+++ b/ui/schema/index.js
@@ -13,7 +13,7 @@ export default [
       label: 'Status',
       format: (val) => (
         <>
-          <Tag status={val.toLowerCase()}>{upperFirst(val)}</Tag>
+          {upperFirst(val)}
           {
             <Details
               className="nhsuk-u-font-size-16 nhsuk-u-margin-top-4"
@@ -44,6 +44,44 @@ export default [
     },
     standard_category: {
       label: 'Type of standard',
+      format: (val) => (
+        <>
+          <Tag type={val.toLowerCase()}>{upperFirst(val)}</Tag>
+          {
+            <Details
+              className="nhsuk-u-font-size-16 nhsuk-u-margin-top-4"
+              summary="What this type means"
+            >
+              <div className="nhsuk-details__text">
+                <Paragraph>
+                  <strong>Technical specifications and APIs</strong> specify how
+                  information is to be made available technically. This includes
+                  how the data is structured and transported, its architecture
+                  and associated protocols.
+                </Paragraph>
+                <Paragraph>
+                  <strong>Clinical and care record standards</strong> define what
+                  information to collect, the purpose of the information and how
+                  to format it for consistency of meaning - for example creating
+                  a standardised way to register a new patient.
+                </Paragraph>
+                <Paragraph>
+                  <strong>Medical and data dictionaries</strong> define the format
+                  of specific data items in ways that allow them to be consistently
+                  represented. Labelling of medicines or formatting of dates of
+                  birth are examples. This category also includes reference sets
+                  and controlled lists.
+                </Paragraph>
+                <Paragraph>
+                  <strong>Data protection and governance</strong> define rules
+                  for what information can be legally processed and how that
+                  information should be securely handled.
+                </Paragraph>
+              </div>
+            </Details>
+          }
+        </>
+      ),
     },
     documentation_help_text: {
       label: 'Documentation',
@@ -113,7 +151,7 @@ export default [
       format: (val) => val || 'None - not legally mandated',
     },
     assurance: {
-      label: 'Quality assured',
+      label: 'Quality assurance',
       format: (val) =>
         (!!val?.length && <MarkdownBlock md={val} />) || 'Not applicable',
     },


### PR DESCRIPTION
* Update the `Tag` component to handle types instead of statuses
* Add a quick and dirty label mapper into the API fetching code to convert the old labels to the new ones
