### PR TITLE
[STAN-399] Add a CSV download button to dataset page

### DIFF
--- a/Dockerfile-ckan
+++ b/Dockerfile-ckan
@@ -14,7 +14,7 @@ RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.13/m
 # Fetch and build the custom CKAN extensions
 RUN pip install -e "git+https://github.com/Marvell-Consulting/ckanext-scheming.git#egg=ckanext-scheming"
 RUN pip install -e "git+https://github.com/Marvell-Consulting/ckanext-pages.git#egg=ckanext-pages"
-RUN pip install -e "git+https://github.com/Marvell-Consulting/ckanext-download-csv-button"
+RUN pip install -e "git+https://github.com/Marvell-Consulting/ckanext-download-csv-button#egg=ckanext-download-csv-button"
 
 # Add the custom extensions to the plugins list
 ENV CKAN__PLUGINS envvars image_view text_view recline_view datastore datapusher scheming_datasets scheming_organizations pages download_csv_button

--- a/Dockerfile-ckan
+++ b/Dockerfile-ckan
@@ -14,9 +14,10 @@ RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.13/m
 # Fetch and build the custom CKAN extensions
 RUN pip install -e "git+https://github.com/Marvell-Consulting/ckanext-scheming.git#egg=ckanext-scheming"
 RUN pip install -e "git+https://github.com/Marvell-Consulting/ckanext-pages.git#egg=ckanext-pages"
+RUN pip install -e "git+https://github.com/Marvell-Consulting/ckanext-download-csv-button"
 
 # Add the custom extensions to the plugins list
-ENV CKAN__PLUGINS envvars image_view text_view recline_view datastore datapusher scheming_datasets scheming_organizations pages
+ENV CKAN__PLUGINS envvars image_view text_view recline_view datastore datapusher scheming_datasets scheming_organizations pages download_csv_button
 
 # Configure ckan
 RUN ckan config-tool ${APP_DIR}/production.ini "ckan.plugins = ${CKAN__PLUGINS}"

--- a/csv-exporter/handler.js
+++ b/csv-exporter/handler.js
@@ -10,7 +10,7 @@ const urls = {
 };
 
 // * choose which env to download from, dev, test, prod
-const urlMap = (env) => urls[env] || urls['dev'];
+const urlMap = (env) => env.includes('http') ? env : urls[env] || urls['dev'];
 
 module.exports.datasets = async (event, context) => {
   const help = [];


### PR DESCRIPTION
### behold

<img width="515" alt="Screenshot 2022-04-21 at 17 19 31" src="https://user-images.githubusercontent.com/120181/164491307-022bed70-d702-414b-b254-c00f4be275e8.png">

### what
Uses our latest and greatest CKAN plugin: https://github.com/Marvell-Consulting/ckanext-download-csv-button

This is where the ~hacking~ [magic happens](https://github.com/Marvell-Consulting/ckanext-download-csv-button/blob/main/ckanext/download_csv_button/templates/package/search.html#L8)

### this is unnecessary
![this is what comes up when you search for csv gifs on the internet](https://c.tenor.com/GdMARwBEzJ0AAAAC/csv-cs%C3%A1sz%C3%A1r.gif)

