### PR TITLE
Wait for serverless to deploy before running integration tests

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -152,6 +152,7 @@ jobs:
     needs:
       - ui
       - ckan
+      - deploy-csv-exporter
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Otherwise the notification may be triggered as a success when the serverless deploy failed.