### PR TITLE
Use default message for failure notification

### DIFF
--- a/.github/workflows/notify-fail.yml
+++ b/.github/workflows/notify-fail.yml
@@ -25,4 +25,3 @@ jobs:
           SLACK_CHANNEL: developers
           SLACK_COLOR: danger
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_TITLE: "Build failed"


### PR DESCRIPTION
`Build failed` is a pretty useless message.