### PR TITLE
[STAN-534] force directory in serverless args

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x]
     environment: dev
     defaults:
       run:
@@ -31,9 +31,9 @@ jobs:
       - name: serverless deploy
         uses: serverless/github-action@v3
         with:
-          args: deploy
+          args: -c "cd ./csv-exporter && serverless deploy --verbose"
+          entrypoint: /bin/sh
         env:
-          # SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_ACCESS_KEY }}
           SLS_DEBUG: 1
           AWS_REGION: eu-west-2
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
The struggle with the serverless config living
outside the root of the folder is  detailed [here](https://github.com/serverless/github-action/issues/53\#issuecomment-1059839383)

The github action _should_ respect sub folders, though we can also force it run from the correct folder