### PR TITLE
pass `--include-optional` flag in dockerfile 

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -7,7 +7,7 @@ RUN apk upgrade --no-cache
 COPY package.json /app/package.json
 COPY package-lock.json /app/package-lock.json
 
-RUN npm ci --production --no-optional --ignore-scripts
+RUN npm ci --production --include-optional --ignore-scripts
 
 COPY . /app
 


### PR DESCRIPTION
Pass in flag to ensure swc binary is downloaded during the dev build process

See: https://nextjs.org/docs/messages/failed-loading-swc

> you might need to allow optional packages to be installed by your package manager (remove --no-optional flag) for the package to download correctly.

Failing build:
https://github.com/nhsx/standards-registry/runs/6368264350?check_suite_focus=true#step:6:70