### PR TITLE
Small filter changes

### DIFF
--- a/ui/components/Dataset/index.js
+++ b/ui/components/Dataset/index.js
@@ -119,7 +119,7 @@ const CheckBox = () => {
         className="nhsuk-label nhsuk-checkboxes__label nhsuk-u-font-size-16"
         htmlFor="mandated"
       >
-        Nationally mandated
+        Mandatory in England
       </label>
     </div>
   );

--- a/ui/components/Expander/index.js
+++ b/ui/components/Expander/index.js
@@ -1,14 +1,20 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import classnames from 'classnames';
-
+import { useEffect } from 'react';
 import styles from './Expander.module.scss';
 
-export default function Expander({ summary, children, className, small, open = false, onToggle = () => {} }) {
-
+export default function Expander({
+  summary,
+  children,
+  className,
+  small,
+  open = false,
+  onToggle = () => {},
+}) {
   const [isOpen, setOpen] = useState(open);
   useEffect(() => {
-    setOpen(open);
-  }, [open])
+    setOpen(true);
+  }, []);
 
   return (
     <details

--- a/ui/components/Expander/index.js
+++ b/ui/components/Expander/index.js
@@ -13,8 +13,10 @@ export default function Expander({
 }) {
   const [isOpen, setOpen] = useState(open);
   useEffect(() => {
-    setOpen(true);
-  }, []);
+    if (!isOpen) {
+      setOpen(open);
+    }
+  }, [open]);
 
   return (
     <details

--- a/ui/components/FilterSummary/index.js
+++ b/ui/components/FilterSummary/index.js
@@ -1,14 +1,16 @@
 import { useQueryContext } from '../../context/query';
-import omit from 'lodash/omit'
-import without from 'lodash/without'
-import size from 'lodash/size'
+import omit from 'lodash/omit';
+import without from 'lodash/without';
+import size from 'lodash/size';
 
-import styles from './FilterSummary.module.scss'
+import styles from './FilterSummary.module.scss';
 
 function Widget({ children, onClick }) {
   return (
-    <div onClick={onClick} className={styles.widget}>X { children }</div>
-  )
+    <div onClick={onClick} className={styles.widget}>
+      X {children}
+    </div>
+  );
 }
 
 export function FilterSummary({ schema }) {
@@ -17,9 +19,9 @@ export function FilterSummary({ schema }) {
   function removeFilter(key, value) {
     const newQuery = {
       ...query,
-      [key]: without(query[key], value)
-    }
-    updateQuery(newQuery)
+      [key]: without(query[key], value),
+    };
+    updateQuery(newQuery);
   }
 
   const activeFilters = omit(query, 'q', 'page', 'sort');
@@ -30,34 +32,35 @@ export function FilterSummary({ schema }) {
 
   return (
     <div className={styles.filterSummary}>
-      {
-        Object.keys(activeFilters).map((key, index) => {
+      {Object.keys(activeFilters)
+        .filter((key) => key !== 'mandated') // don't show mandated widget
+        .map((key, index) => {
           let filters = activeFilters[key];
-          const settings = schema.dataset_fields.find(f => f.field_name === key);
+          const settings = schema.dataset_fields.find(
+            (f) => f.field_name === key
+          );
           if (!Array.isArray(filters)) {
-            filters = [filters]
+            filters = [filters];
           }
           return (
             <div key={key} className={styles.filterSection}>
               <h4>
-                { index > 0 && 'and '}
+                {index > 0 && 'and '}
                 {settings.label}
               </h4>
-              {
-                filters.map((filter, i) => {
-                  return (
-                    <span key={i}>
-                      {i > 0 && <span className={styles.and}>and</span>}
-                      <Widget onClick={() => removeFilter(key, filter)}>{filter}</Widget>
-                    </span>
-                  )
-                })
-              }
+              {filters.map((filter, i) => {
+                return (
+                  <span key={i}>
+                    {i > 0 && <span className={styles.and}>and</span>}
+                    <Widget onClick={() => removeFilter(key, filter)}>
+                      {filter}
+                    </Widget>
+                  </span>
+                );
+              })}
             </div>
-          )
-        })
-      }
+          );
+        })}
     </div>
-
-  )
+  );
 }

--- a/ui/components/Filters/index.js
+++ b/ui/components/Filters/index.js
@@ -70,7 +70,6 @@ export default function Filters({ schema }) {
   const selections = getSelections();
   const categories = ['care_setting', 'topic', 'standard_category'];
   const filters = pick(categories, fields);
-  const allOpen = openFilters.length === filters.length;
 
   const addFilter = (filter) => {
     const selections = getSelections();
@@ -125,16 +124,6 @@ export default function Filters({ schema }) {
   };
   useEffect(setSelections, [selections]);
 
-  const openAll = (event) => {
-    event.preventDefault();
-    setOpenFilters(filters.map((f) => f.field_name));
-  };
-
-  const closeAll = (event) => {
-    event.preventDefault();
-    setOpenFilters([]);
-  };
-
   const toggle = (name, isOpen) => {
     const open = new Set(openFilters);
     isOpen ? open.add(name) : open.delete(name);
@@ -146,17 +135,6 @@ export default function Filters({ schema }) {
   return (
     <div className="nhsuk-filters">
       <h3>Filters</h3>
-      <p className={styles.toggleAll}>
-        {allOpen ? (
-          <a href="" onClick={closeAll}>
-            Close all
-          </a>
-        ) : (
-          <a href="" onClick={openAll}>
-            Open all
-          </a>
-        )}
-      </p>
       <div className="nhsuk-expander-group">
         {filters.map((filter, index) => {
           let fieldFilters = activeFilters[filter.field_name] || [];

--- a/ui/components/Filters/index.js
+++ b/ui/components/Filters/index.js
@@ -32,30 +32,31 @@ function Filter({
     updateQuery({ ...query, [fieldName]: val || [] });
   }
 
-  return (
+  return useSelect ? (
+    <>
+      {summary}
+      <Select
+        options={choices}
+        onChange={onSelectChange}
+        showAll={true}
+        value={query[fieldName] || ''}
+      />
+    </>
+  ) : (
     <Expander
       summary={summary}
       className="nhsuk-filter"
       open={open}
       onToggle={toggle}
     >
-      {useSelect ? (
-        <Select
+      <OptionSelect>
+        <CheckboxGroup
+          onChange={onChange}
           options={choices}
-          onChange={onSelectChange}
-          showAll={true}
-          value={query[fieldName] || ''}
+          parent={fieldName}
+          small
         />
-      ) : (
-        <OptionSelect>
-          <CheckboxGroup
-            onChange={onChange}
-            options={choices}
-            parent={fieldName}
-            small
-          />
-        </OptionSelect>
-      )}
+      </OptionSelect>
     </Expander>
   );
 }

--- a/ui/components/Filters/index.js
+++ b/ui/components/Filters/index.js
@@ -142,6 +142,10 @@ export default function Filters({ schema }) {
             fieldFilters = [fieldFilters];
           }
           const numActive = fieldFilters.length;
+          // TODO: should be set in schema, hack until we change it
+          if (filter.label === 'Type of standard') {
+            filter.label = 'Type';
+          }
           return (
             <Filter
               key={index}

--- a/ui/components/Filters/index.js
+++ b/ui/components/Filters/index.js
@@ -12,7 +12,7 @@ function Filter({
   field_name: fieldName,
   open,
   onToggle,
-  andFilter,
+  useSelect,
   numActive = 0,
 }) {
   const { query, updateQuery } = useQueryContext();
@@ -24,7 +24,7 @@ function Filter({
     <p className={styles.filterHeader}>
       {label}
 
-      {!andFilter && <span>{numActive} selected</span>}
+      {!useSelect && <span>{numActive} selected</span>}
     </p>
   );
 
@@ -39,7 +39,7 @@ function Filter({
       open={open}
       onToggle={toggle}
     >
-      {andFilter ? (
+      {useSelect ? (
         <Select
           options={choices}
           onChange={onSelectChange}
@@ -155,7 +155,7 @@ export default function Filters({ schema }) {
               onToggle={toggle}
               numActive={numActive}
               // TODO: this should be configured in schema
-              andFilter={filter.field_name === 'standard_category'}
+              useSelect={filter.field_name === 'standard_category'}
             />
           );
         })}

--- a/ui/cypress/integration/standards/list.js
+++ b/ui/cypress/integration/standards/list.js
@@ -104,7 +104,7 @@ describe('Standards Listing Index', () => {
         cy.get('#resultSummary')
           .invoke('attr', 'data-loading')
           .should('eq', 'false');
-        cy.get('#browse-results li a').eq(0).click();
+        cy.get('#browse-results li a').eq(0).click({ force: true });
 
         cy.contains('td', 'NHS Digital');
 

--- a/ui/cypress/integration/standards/list.js
+++ b/ui/cypress/integration/standards/list.js
@@ -98,12 +98,15 @@ describe('Standards Listing Index', () => {
 
       it('Matches various variations of nhs', () => {
         cy.visit('/standards');
-        cy.get('input[name="q"]').type('nhsd', { force: true });
+        cy.get('input[name="q"]').type('nhsd');
 
         cy.contains('Search').click();
         cy.get('#resultSummary')
           .invoke('attr', 'data-loading')
           .should('eq', 'false');
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(500);
+
         cy.get('#browse-results li a').eq(0).click({ force: true });
 
         cy.contains('td', 'NHS Digital');

--- a/ui/cypress/integration/standards/list.js
+++ b/ui/cypress/integration/standards/list.js
@@ -101,6 +101,9 @@ describe('Standards Listing Index', () => {
         cy.get('input[name="q"]').type('nhsd', { force: true });
 
         cy.contains('Search').click();
+        cy.get('#resultSummary')
+          .invoke('attr', 'data-loading')
+          .should('eq', 'false');
         cy.get('#browse-results li a').eq(0).click();
 
         cy.contains('td', 'NHS Digital');


### PR DESCRIPTION
* Type no longer in expander to avoid unnecessary click:

<img width="246" alt="Screenshot 2022-05-16 at 16 38 45" src="https://user-images.githubusercontent.com/120181/168618362-872133bc-d9d4-479b-a6e4-2941123c256a.png">

* removes open/close all link

**before**
<img width="252" alt="Screenshot 2022-05-16 at 16 42 10" src="https://user-images.githubusercontent.com/120181/168619171-4c51ae3c-38b3-44f3-a7a4-5932b556f440.png">

**after:**
<img width="277" alt="Screenshot 2022-05-16 at 16 41 43" src="https://user-images.githubusercontent.com/120181/168619018-55d225a4-d1ee-4cbc-a677-757cc35c290e.png">

* only open expanders with selected options on page load (fixes as clash in which you could open an adjacent expander by clicking the options in another one)

* Temporarily hacks "type of standard" to "type", we will change this in ckan

* Mandated in england content change