### PR TITLE
[STAN-557] Search and Filter fixes

### DIFF
--- a/ui/components/Expander/Expander.module.scss
+++ b/ui/components/Expander/Expander.module.scss
@@ -12,6 +12,9 @@
 
 .summary {
   display: block;
+  &:before {
+    margin: 8px 2px;
+  }
 }
 
 .detailsText {

--- a/ui/components/FilterSummary/index.js
+++ b/ui/components/FilterSummary/index.js
@@ -24,7 +24,7 @@ export function FilterSummary({ schema }) {
     updateQuery(newQuery);
   }
 
-  const chosenFilters = omit(query, 'q', 'page', 'sort');
+  const chosenFilters = omit(query, 'q', 'page', 'sort', 'mandated');
 
   if (!size(chosenFilters)) {
     return null;
@@ -38,34 +38,32 @@ export function FilterSummary({ schema }) {
 
   return (
     <div className={styles.filterSummary}>
-      {Object.keys(activeFilters)
-        .filter((key) => key !== 'mandated') // don't show mandated widget
-        .map((key, index) => {
-          let filters = activeFilters[key];
-          const settings = schema.dataset_fields.find(
-            (f) => f.field_name === key
-          );
-          if (!Array.isArray(filters)) {
-            filters = [filters];
-          }
-          return (
-            <div key={key} className={styles.filterSection}>
-              {settings.label.toLowerCase() === 'type' && index >= 1 ? (
-                <h4>In</h4>
-              ) : null}
-              {filters.map((filter, i) => {
-                return (
-                  <span key={i}>
-                    {i > 0 && <span className={styles.and}>and</span>}
-                    <Widget onClick={() => removeFilter(key, filter)}>
-                      {filter}
-                    </Widget>
-                  </span>
-                );
-              })}
-            </div>
-          );
-        })}
+      {Object.keys(activeFilters).map((key, index) => {
+        let filters = activeFilters[key];
+        const settings = schema.dataset_fields.find(
+          (f) => f.field_name === key
+        );
+        if (!Array.isArray(filters)) {
+          filters = [filters];
+        }
+        return (
+          <div key={key} className={styles.filterSection}>
+            {settings.label.toLowerCase() === 'type' && index >= 1 ? (
+              <h4>In</h4>
+            ) : null}
+            {filters.map((filter, i) => {
+              return (
+                <span key={i}>
+                  {i > 0 && <span className={styles.and}>and</span>}
+                  <Widget onClick={() => removeFilter(key, filter)}>
+                    {filter}
+                  </Widget>
+                </span>
+              );
+            })}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/ui/components/FilterSummary/index.js
+++ b/ui/components/FilterSummary/index.js
@@ -24,11 +24,17 @@ export function FilterSummary({ schema }) {
     updateQuery(newQuery);
   }
 
-  const activeFilters = omit(query, 'q', 'page', 'sort');
+  const chosenFilters = omit(query, 'q', 'page', 'sort');
 
-  if (!size(activeFilters)) {
+  if (!size(chosenFilters)) {
     return null;
   }
+  const { standard_category } = chosenFilters;
+  // trick to resort category to be last,
+  // TODO: better sorting needed
+  const activeFilters = standard_category
+    ? { ...chosenFilters, standard_category }
+    : chosenFilters;
 
   return (
     <div className={styles.filterSummary}>
@@ -44,10 +50,9 @@ export function FilterSummary({ schema }) {
           }
           return (
             <div key={key} className={styles.filterSection}>
-              <h4>
-                {index > 0 && 'and '}
-                {settings.label}
-              </h4>
+              {settings.label.toLowerCase() === 'type' && index >= 1 ? (
+                <h4>In</h4>
+              ) : null}
               {filters.map((filter, i) => {
                 return (
                   <span key={i}>

--- a/ui/components/Filters/Filters.module.scss
+++ b/ui/components/Filters/Filters.module.scss
@@ -1,16 +1,12 @@
 @import 'vars';
 
-.summary {
-  border: 10px solid yellow;
-  &:before {
-    border: 10px solid lime !important;
-    margin: 8px 2px;
-  }
-}
-
 .toggleAll {
   text-align: right;
   font-size: 16px;
+}
+
+.filterTypeHeader {
+  padding-top: $nhsuk-gutter;
 }
 
 .filterHeader {

--- a/ui/components/Filters/Filters.module.scss
+++ b/ui/components/Filters/Filters.module.scss
@@ -1,4 +1,12 @@
-@import "vars";
+@import 'vars';
+
+.summary {
+  border: 10px solid yellow;
+  &:before {
+    border: 10px solid lime !important;
+    margin: 8px 2px;
+  }
+}
 
 .toggleAll {
   text-align: right;

--- a/ui/components/Filters/index.js
+++ b/ui/components/Filters/index.js
@@ -38,11 +38,7 @@ function Filter({
       />
     </>
   ) : (
-    <Expander
-      summary={summary}
-      className="nhsuk-filter"
-      open={open}
-    >
+    <Expander summary={summary} className="nhsuk-filter" open={open}>
       <OptionSelect>
         <CheckboxGroup
           onChange={onChange}
@@ -108,17 +104,16 @@ export default function Filters({ schema }) {
     <div className="nhsuk-filters">
       <h3>Filters</h3>
       <div className="nhsuk-expander-group">
-        {filters.map(filter => {
+        {filters.map((filter) => {
           let fieldFilters = activeFilters[filter.field_name] || [];
           if (!Array.isArray(fieldFilters)) {
             fieldFilters = [fieldFilters];
           }
           const numActive = fieldFilters.length;
-          // TODO: should be set in schema, hack until we change it
-          if (filter.label === 'Type of standard') {
-            filter.label = 'Type';
-          }
-          filter.choices = filter.choices.map(opt => ({ ...opt, checked: fieldFilters.includes(opt.value) }));
+          filter.choices = filter.choices.map((opt) => ({
+            ...opt,
+            checked: fieldFilters.includes(opt.value),
+          }));
 
           return (
             <Filter

--- a/ui/components/Search/index.js
+++ b/ui/components/Search/index.js
@@ -39,7 +39,7 @@ export default function Search({
   function onFormSubmit(e) {
     e.preventDefault();
     delete query.page; // remove page depth from query when submitting a new search
-    if (navigate) {
+    if (navigate || location === 'nav') {
       router.push(`/search-results?q=${value || ''}`);
     } else {
       updateQuery({ ...query, q: value });

--- a/ui/components/Search/index.js
+++ b/ui/components/Search/index.js
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import classnames from 'classnames';
+import { useRouter } from 'next/router';
 import { useQueryContext } from '../../context/query';
 import styles from './style.module.scss';
 
@@ -29,14 +30,20 @@ export default function Search({
   label = true,
   labelText = 'Search directory',
   location = null,
+  navigate = null,
 }) {
+  const router = useRouter();
   const { query, updateQuery } = useQueryContext();
   const [value, setValue] = useState(query.q);
 
   function onFormSubmit(e) {
     e.preventDefault();
     delete query.page; // remove page depth from query when submitting a new search
-    updateQuery({ ...query, q: value });
+    if (navigate) {
+      router.push(`/search-results?q=${value || ''}`);
+    } else {
+      updateQuery({ ...query, q: value });
+    }
     return false;
   }
 

--- a/ui/cypress/integration/home.js
+++ b/ui/cypress/integration/home.js
@@ -1,13 +1,31 @@
 describe('Homepage', () => {
   it('should show home page and call to action', () => {
     cy.visit('/');
-    cy.contains('Find standards for data and interoperability in health and social care');
-    cy.contains('Use this directory to find nationally recognised information standards for interoperable technology in health and adult social care.')
+    cy.contains(
+      'Find standards for data and interoperability in health and social care'
+    );
+    cy.contains(
+      'Use this directory to find nationally recognised information standards for interoperable technology in health and adult social care.'
+    );
   });
 
   it('should show recent standards on the right hand side', () => {
     cy.visit('/');
 
-    cy.get('ul#recent-standards li').should('have.length', 3)
+    cy.get('ul#recent-standards li').should('have.length', 3);
+  });
+
+  describe('Search', () => {
+    it('Can search from the homepage', () => {
+      cy.visit('/');
+      cy.doSearch('allergies');
+      cy.get('#browse-results li').should('have.length', 1);
+    });
+    it('Blank search returns results', () => {
+      cy.visit('/');
+      // cy.wait(1);
+      cy.doSearch(' ');
+      cy.get('#browse-results li').not('have.length', 0);
+    });
   });
 });

--- a/ui/cypress/integration/standards/standard-page.js
+++ b/ui/cypress/integration/standards/standard-page.js
@@ -1,7 +1,6 @@
 describe('Standards', () => {
-  it('should be able to access a content standards model', async () => {
+  it('should be able to access a content standards model', () => {
     cy.visit('/standards/about-me');
-
     cy.contains('h1', 'About Me');
   });
 });

--- a/ui/cypress/integration/static-page.js
+++ b/ui/cypress/integration/static-page.js
@@ -1,0 +1,9 @@
+describe('Static page', () => {
+  describe('Search', () => {
+    it('Can search from the nav search', () => {
+      cy.visit('/community');
+      cy.doSearch('allergies');
+      cy.get('#browse-results li').should('have.length', 1);
+    });
+  });
+});

--- a/ui/cypress/support/commands.js
+++ b/ui/cypress/support/commands.js
@@ -12,8 +12,7 @@
 // -- This is a parent command --
 // Cypress.Commands.add('login', (email, password) => { ... })
 Cypress.Commands.add('doSearch', (term) => {
-  cy.get('input[name="q"]').type(term);
-  cy.contains('button', 'Search').click();
+  cy.get('input[name="q"]').type(`${term}{enter}`);
   cy.get('#resultSummary').invoke('attr', 'data-loading').should('eq', 'false');
 });
 //

--- a/ui/cypress/support/commands.js
+++ b/ui/cypress/support/commands.js
@@ -13,10 +13,8 @@
 // Cypress.Commands.add('login', (email, password) => { ... })
 Cypress.Commands.add('doSearch', (term) => {
   cy.get('input[name="q"]').type(term);
-  cy.contains('Search').click();
-  cy.get('#resultSummary')
-    .invoke('attr', 'data-loading')
-    .should('eq', 'false');
+  cy.contains('button', 'Search').click();
+  cy.get('#resultSummary').invoke('attr', 'data-loading').should('eq', 'false');
 });
 //
 // -- This is a child command --


### PR DESCRIPTION
* Removing the router 'navigate' option from search broke search from the homepage
* this adds it back in and also fixes an in issue in which passing a blank search from the homepage would cause a search for the string 'undefined' (now it searches for `""`, bringing back all results)

**Filter updates**
* filter headings removed unless you have several selected and _then_ select a `Type` (we write "in" for that)
<img width="756" alt="Screenshot 2022-05-17 at 17 14 29" src="https://user-images.githubusercontent.com/120181/168851230-75c8e283-9f50-4440-9c73-290c6160d097.png">
* expander icons aligned with headings
<img width="272" alt="Screenshot 2022-05-17 at 17 37 29" src="https://user-images.githubusercontent.com/120181/168851458-63dca718-148c-482b-bb36-50e53930db2a.png">
* When clicking "mandated" alone we no longer get two lines across the filter summary section

### **before**
<img width="736" alt="Screenshot 2022-05-17 at 17 49 55" src="https://user-images.githubusercontent.com/120181/168854409-9678b353-a26b-436e-ad79-ab75758f5831.png">

### **after**

<img width="686" alt="Screenshot 2022-05-17 at 17 49 47" src="https://user-images.githubusercontent.com/120181/168854423-76abe510-11ea-4b80-a4a1-415948631543.png">

