### PR TITLE
Fix prettier test run

### DIFF
--- a/ui/.prettierignore
+++ b/ui/.prettierignore
@@ -1,0 +1,9 @@
+# Ignore build artifacts
+coverage
+.next
+package-lock.json
+
+*.md
+
+# Ignore all HTML files
+*.html

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint",
     "cypress:open": "cypress open",
     "prettier": "pretty-quick --write",
-    "test": "next lint && pretty-quick --check && jest",
+    "test": "next lint && prettier --check . && jest",
     "test:integration": "cypress run",
     "test:watch": "jest --watch"
   },


### PR DESCRIPTION
* `pretty-quick` only runs on files that are changed since the last commit, so won't work in CI by definition. Replace prettier implementation in `npm test` with `prettier`.
* `.prettierignore` file needs to be in the UI directory to be read correctly by that command.