### PR TITLE
More accessibility fixes

### DIFF
--- a/ui/components/Dataset/index.js
+++ b/ui/components/Dataset/index.js
@@ -163,7 +163,7 @@ const NoResultsSummary = ({ searchTerm }) => (
 );
 
 const ResultSummary = ({ count, searchTerm, filtersSelected, loading }) => (
-  <h3 id="resultSummary" data-loading={loading}>
+  <h2 id="resultSummary" data-loading={loading}>
     {(loading && 'Searching for results') || (
       <Snippet
         num={count}
@@ -174,7 +174,7 @@ const ResultSummary = ({ count, searchTerm, filtersSelected, loading }) => (
         {searchTerm || filtersSelected ? 'filters.summary' : 'filters.all'}
       </Snippet>
     )}
-  </h3>
+  </h2>
 );
 
 export default function Dataset({

--- a/ui/components/Filters/Filters.module.scss
+++ b/ui/components/Filters/Filters.module.scss
@@ -5,10 +5,6 @@
   font-size: 16px;
 }
 
-.filterTypeHeader {
-  padding-top: $nhsuk-gutter;
-}
-
 .filterHeader {
   margin-bottom: 0;
   padding-bottom: $nhsuk-gutter;

--- a/ui/components/Filters/index.js
+++ b/ui/components/Filters/index.js
@@ -15,9 +15,7 @@ function Filter({
   numActive = 0,
 }) {
   const { query, updateQuery } = useQueryContext();
-  const summary = useSelect ? (
-    <h4 className={styles.filterTypeHeader}>{label}</h4>
-  ) : (
+  const summary = useSelect ? null : (
     <p className={styles.filterHeader}>
       {label}
 
@@ -30,15 +28,17 @@ function Filter({
   }
 
   return useSelect ? (
-    <>
+    <label className="nhsuk-heading-m nhsuk-u-padding-top-3">
+      {label}
       {summary}
       <Select
+        className="nhsuk-u-padding-top-4"
         options={choices}
         onChange={onSelectChange}
         showAll={true}
         value={query[fieldName] || ''}
       />
-    </>
+    </label>
   ) : (
     <Expander summary={summary} className="nhsuk-filter" open={open}>
       <OptionSelect>

--- a/ui/components/Form/CheckboxGroup.js
+++ b/ui/components/Form/CheckboxGroup.js
@@ -44,7 +44,7 @@ export default function CheckboxGroup({
       )}
     >
       <fieldset id={id || name} className="nhsuk-fieldset">
-        <legend className="nhsuk-fieldset__legend">{legend}</legend>
+        {legend && <legend className="nhsuk-fieldset__legend">{legend}</legend>}
         {hint && <div className="nhsuk-hint">{hint}</div>}
         <div
           className={classnames('nhsuk-checkboxes', styles.checkboxes, {

--- a/ui/components/Layout/index.js
+++ b/ui/components/Layout/index.js
@@ -43,6 +43,7 @@ export default function Home({ children, ...props }) {
                   >
                     <svg
                       className="nhsuk-logo"
+                      focusable="false"
                       xmlns="http://www.w3.org/2000/svg"
                       viewBox="0 0 40 16"
                       height="40"

--- a/ui/components/Search/index.js
+++ b/ui/components/Search/index.js
@@ -15,12 +15,19 @@ const SearchIcon = () => (
     aria-hidden="true"
     focusable="false"
   >
-    <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
+    <path
+      role="img"
+      alt="magnifying glass"
+      d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"
+    ></path>
   </svg>
 );
 
 const SearchButton = ({ style, children }) => (
-  <button className={classnames('nhsuk-search__submit', style)}>
+  <button
+    aria-label="search button"
+    className={classnames('nhsuk-search__submit', style)}
+  >
     {children}
   </button>
 );

--- a/ui/components/Select/index.js
+++ b/ui/components/Select/index.js
@@ -7,20 +7,21 @@ export function Select({
   value,
   label,
   showAll,
+  name,
   className,
 }) {
   return (
     <div className={classNames('nhsuk-form-group', className)}>
       {label && (
-        <label className="nhsuk-label nhsuk-u-font-size-16" htmlFor={id}>
+        <label className="nhsuk-label nhsuk-u-font-size-16" htmlFor={name}>
           {label}
         </label>
       )}
 
       <select
         className="nhsuk-select nhsuk-u-font-size-16"
-        name={id}
-        id={id}
+        name={name}
+        id={id || name}
         onChange={(e) => onChange(e.target.value)}
         value={value}
       >

--- a/ui/components/Select/index.js
+++ b/ui/components/Select/index.js
@@ -1,6 +1,16 @@
-export function Select({ options, onChange, id, value, label, showAll }) {
+import classNames from 'classnames';
+
+export function Select({
+  options,
+  onChange,
+  id,
+  value,
+  label,
+  showAll,
+  className,
+}) {
   return (
-    <div className="nhsuk-form-group">
+    <div className={classNames('nhsuk-form-group', className)}>
       {label && (
         <label className="nhsuk-label nhsuk-u-font-size-16" htmlFor={id}>
           {label}


### PR DESCRIPTION
This PR is a collection of responses to the use of the [ARC accessibility toolkit](https://www.tpgi.com/arc-platform/arc-toolkit/)

Fixes: 
* [STAN-627 empty legend](https://standardsportal.atlassian.net/browse/STAN-627)
* [STAN-628 accessible name for select](https://standardsportal.atlassian.net/browse/STAN-628)

### Put a label on the search button when using just an icon

<img width="406" alt="Screenshot 2022-05-27 at 12 14 20" src="https://user-images.githubusercontent.com/120181/170685698-4b7d5bb8-6c5b-4aef-9170-6bd370975f36.png">

[add labels to search button when using icon](https://github.com/nhsx/standards-registry/commit/4e3b76ca71aae05ded58df483b7f1a54b4bdfd74)


### Fix an issue with label not matching corresponding select

[ensure label corresponds to select](https://github.com/nhsx/standards-registry/commit/bc8dc269d7b3ad6c849debb606e6917c718e32d1)

### Switch heading to label for filter select

[swap out heading for label in filter select](https://github.com/nhsx/standards-registry/commit/866f876c25425dedd9d949b07c465d0a246fde40)

<img width="356" alt="Screenshot 2022-05-27 at 12 51 28" src="https://user-images.githubusercontent.com/120181/170685956-0b4a5fd4-2a4a-4f90-9ef1-4c0dd707a248.png">

### Remove svg focus on logo

[set SVG focusable to false](https://github.com/nhsx/standards-registry/commit/73b55fabaaef6484a55e894134fc09b59d6edb83)2