### PR TITLE
[STAN-631] simplify markdown rendering

### DIFF
--- a/ui/components/MarkdownBlock/index.js
+++ b/ui/components/MarkdownBlock/index.js
@@ -1,20 +1,9 @@
-import { parse } from 'marked';
-
-const createMarkup = (htmlstr) => {
-  return {
-    __html: htmlstr,
-  };
-};
+import ReactMarkdown from 'react-markdown';
 
 export default function MarkdownBlock({ md }) {
   return (
-    <div
-      className="nhsuk-u-font-size-16"
-      dangerouslySetInnerHTML={createMarkup(parse(md))}
-    />
+    <div className="nhsuk-u-font-size-16">
+      <ReactMarkdown>{md}</ReactMarkdown>
+    </div>
   );
 }
-
-export const MarkdownRender = ({ md }) => (
-  <div dangerouslySetInnerHTML={createMarkup(parse(md))} />
-);

--- a/ui/package.json
+++ b/ui/package.json
@@ -15,12 +15,10 @@
   },
   "dependencies": {
     "axios": "^0.27.2",
-    "body-parser": "^1.19.0",
     "classnames": "^2.3.1",
     "date-fns": "^2.25.0",
     "isomorphic-dompurify": "^0.19.0",
     "lodash": "^4.17.21",
-    "marked": "^4.0.5",
     "mdast-util-from-markdown": "^1.2.0",
     "mustache": "^4.2.0",
     "next": "^12.1.6",
@@ -29,10 +27,10 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-markdown": "^6.0.3",
-    "sass": "^1.43.2",
     "urlencoded-body-parser": "^3.0.0"
   },
   "devDependencies": {
+    "sass": "^1.43.2",
     "@babel/preset-env": "^7.17.12",
     "@babel/preset-react": "^7.17.12",
     "cypress": "^9.5.4",

--- a/ui/pages/[page].js
+++ b/ui/pages/[page].js
@@ -1,5 +1,6 @@
-import { Page, MarkdownRender, TableOfContents } from '../components';
+import { Page, TableOfContents } from '../components';
 import { getPages } from '../helpers/api';
+import ReactMarkdown from 'react-markdown';
 
 const StaticPage = ({ pageData }) => {
   const { content, title, show_table_of_contents: showContents } = pageData;
@@ -9,7 +10,7 @@ const StaticPage = ({ pageData }) => {
         {showContents && <TableOfContents content={content} />}
         <div className="nhsuk-grid-column-two-thirds">
           <h1>{title}</h1>
-          <MarkdownRender md={content} />
+          <ReactMarkdown>{content}</ReactMarkdown>
         </div>
       </div>
     </Page>


### PR DESCRIPTION
* just use `react-markdown` for rendering markdown
* remove unused `marked` and `body-parser` dependencies

<img width="1008" alt="Screenshot 2022-05-27 at 14 35 42" src="https://user-images.githubusercontent.com/120181/170700481-0f505351-0905-4a1a-b1d4-8fbd77e96da6.png">

<img width="367" alt="Screenshot 2022-05-27 at 14 37 20" src="https://user-images.githubusercontent.com/120181/170700529-a9bd3c5e-a642-4275-b756-11db44b0790f.png">

