### PR TITLE
[STAN-519] simplify search button style states

### DIFF
--- a/ui/components/Search/style.module.scss
+++ b/ui/components/Search/style.module.scss
@@ -1,3 +1,4 @@
+@import 'vars';
 @import 'node_modules/nhsuk-frontend/packages/core/tools/_sass-mq.scss';
 @import 'node_modules/nhsuk-frontend/packages/core/settings/_colours.scss';
 
@@ -23,12 +24,11 @@
   padding: 8px;
   &:hover {
     border: none;
-    background-color: $color_nhsuk-grey-1;
   }
   &:active,
   &:focus {
-    outline: 0px;
-    color: white;
+    box-shadow: none;
+    background: $yellow;
   }
 }
 


### PR DESCRIPTION
* Updates the search button styles to have a yellow background with black text when clicked.
* All states should have sufficient contrast
* Also checked the feedback link, which seems to respond as expected 

Hover state
<img width="111" alt="Screenshot 2022-05-27 at 15 22 21" src="https://user-images.githubusercontent.com/120181/170708321-a4a714ec-e5e9-411a-9115-714dd4f1e6dd.png">
Selected
<img width="657" alt="Screenshot 2022-05-27 at 15 22 16" src="https://user-images.githubusercontent.com/120181/170708323-80e19903-20e8-4621-9e31-7f412ad582ca.png">
input focused
<img width="674" alt="Screenshot 2022-05-27 at 15 22 12" src="https://user-images.githubusercontent.com/120181/170708342-d4e4f600-9907-4fee-84e6-a269fe9b572d.png">
feedback link focused
<img width="202" alt="Screenshot 2022-05-27 at 15 15 37" src="https://user-images.githubusercontent.com/120181/170708343-35e87a5e-6654-47a3-98ad-7781316012c9.png">
Icon focused
<img width="96" alt="Screenshot 2022-05-27 at 15 29 44" src="https://user-images.githubusercontent.com/120181/170709069-84689fd6-b9de-4eb0-b7e7-f857b1895aef.png">

