### PR TITLE
[UI] Redo header nav search

### DIFF
--- a/ui/components/Grid/index.js
+++ b/ui/components/Grid/index.js
@@ -42,7 +42,10 @@ export function Row({ children, className }) {
 
   return (
     <div className={classnames('nhsuk-grid-row', className)}>
-      {Children.map(children, (child) => cloneElement(child, { total }))}
+      {Children.map(
+        children,
+        (child) => child && cloneElement(child, { total })
+      )}
     </div>
   );
 }

--- a/ui/components/Layout/index.js
+++ b/ui/components/Layout/index.js
@@ -72,11 +72,9 @@ export default function Home({ children, ...props }) {
                 </Link>
               </div>
             </Col>
-            <Col>
-              {!props.hideBannerSearch && (
-                <Search label={false} placeholder="Search" location="nav" />
-              )}
-            </Col>
+            {!props.hideBannerSearch && (
+              <Search label={false} placeholder="Search" location="nav" />
+            )}
           </Row>
         </div>
         <Navigation />

--- a/ui/components/Search/index.js
+++ b/ui/components/Search/index.js
@@ -55,14 +55,29 @@ export default function Search({
   }
 
   return (
-    <div className="nhsuk-form-group">
+    <div
+      className={classnames(
+        'nhsuk-form-group',
+        location === 'nav' && styles.searchFormInNavWrapper
+      )}
+    >
       <form
-        className={classnames('nhsuk-search', styles.search)}
+        className={classnames(
+          'nhsuk-search',
+          styles.search,
+          location === 'nav' && styles.searchInNav
+        )}
         method="GET"
         action="/search-results"
         onSubmit={onFormSubmit}
       >
-        <label className={'nhsuk-label'}>
+        <label
+          className={classnames(
+            'nhsuk-label',
+            styles.searchLabel,
+            location === 'nav' && styles.labelInNav
+          )}
+        >
           {label && labelText}
           <input
             type="text"

--- a/ui/components/Search/style.module.scss
+++ b/ui/components/Search/style.module.scss
@@ -26,7 +26,6 @@
   background-color: $color_nhsuk-grey-5;
   &:focus {
     border: none;
-    box-shadow: none;
   }
 }
 

--- a/ui/components/Search/style.module.scss
+++ b/ui/components/Search/style.module.scss
@@ -2,14 +2,32 @@
 @import 'node_modules/nhsuk-frontend/packages/core/tools/_sass-mq.scss';
 @import 'node_modules/nhsuk-frontend/packages/core/settings/_colours.scss';
 
+.searchFormInNavWrapper {
+  float: right;
+  margin-right: $nhsuk-gutter;
+  margin-bottom: $nhsuk-gutter;
+}
+
 .search {
   position: relative;
+}
+
+.searchInNav {
+  display: inline-block;
+}
+
+.labelInNav {
+  float: left;
 }
 
 .input {
   padding-left: 0.5em;
   border: none;
   background-color: $color_nhsuk-grey-5;
+  &:focus {
+    border: none;
+    box-shadow: none;
+  }
 }
 
 .buttonText {
@@ -33,18 +51,16 @@
 }
 
 .button {
-  position: absolute;
   line-height: 50%;
-  bottom: 0;
-  right: 0;
 }
 
 @include mq($until: tablet) {
-  .input {
-    margin: 10px 0 0;
+  .searchFormInNavWrapper {
+    float: left;
+    margin: $nhsuk-gutter;
   }
   .button {
-    width: 40px;
+    width: 44px;
     height: 40px;
     padding: 1px;
 
@@ -59,10 +75,3 @@
     height: 27px !important;
   }
 }
-
-// Placeholder for tablet+ specific styling
-// @include mq($from: tablet) {
-// .button {
-// background-color: red;
-// }
-// }


### PR DESCRIPTION
Before
<img width="325" alt="Screenshot 2022-05-27 at 17 01 00" src="https://user-images.githubusercontent.com/120181/170727946-7d84a941-b077-442c-a405-e19b869c03ca.png">

After
<img width="294" alt="Screenshot 2022-05-27 at 17 17 16" src="https://user-images.githubusercontent.com/120181/170728904-580d79de-7c89-45f2-ae81-3cd31a83d902.png">

Matching up to the way search is done in the nav on NHS service manual

<img width="929" alt="Screenshot 2022-05-27 at 17 12 21" src="https://user-images.githubusercontent.com/120181/170728157-04261934-a288-4913-9ef1-d7cab0107ace.png">

