### PR TITLE
Switch all "exactly 1" assertions to "at least 1"

### DIFF
--- a/ui/cypress/integration/standards/list.js
+++ b/ui/cypress/integration/standards/list.js
@@ -21,7 +21,7 @@ describe('Standards Listing Index', () => {
       cy.visit('/standards');
       cy.doSearch('alergy');
 
-      cy.get('#browse-results li').should('have.length', 1);
+      cy.get('#browse-results li').should('have.length.of.at.least', 1);
       cy.contains('#browse-results li', 'Allergy').click();
     });
 

--- a/ui/cypress/integration/static-page.js
+++ b/ui/cypress/integration/static-page.js
@@ -3,7 +3,7 @@ describe('Static page', () => {
     it('Can search from the nav search', () => {
       cy.visit('/community');
       cy.doSearch('allergies');
-      cy.get('#browse-results li').should('have.length', 1);
+      cy.get('#browse-results li').should('have.length.of.at.least', 1);
     });
   });
 });


### PR DESCRIPTION
- Should get us out of the woods with integration test failures
  happening occuring when data changes and we get more results for
  specific pathways