### PR TITLE
Remove title from search results heading

### DIFF
--- a/ui/pages/search-results.js
+++ b/ui/pages/search-results.js
@@ -14,7 +14,7 @@ import { getPageProps } from '../helpers/getPageProps';
 import { useQueryContext } from '../context/query';
 
 const content = {
-  title: 'Search results - NHS Standards Directory',
+  title: 'Search results',
   filters: {
     summary: '{{num}} item{{#plural}}s{{/plural}} related to: "{{searchTerm}}"',
     all: '{{num}} result{{#plural}}s{{/plural}}',
@@ -28,7 +28,7 @@ export default function SearchResults({ data, schemaData }) {
     ? [query.q, content.title].join(' - ')
     : content.title;
   return (
-    <Page title={title}>
+    <Page title={`${title} - NHS Standards Directory`}>
       <h1>
         <Snippet inline>title</Snippet>
       </h1>


### PR DESCRIPTION
- before we'd use the same title for the page html title *and* for the results heading
- now we just show "Search results" in the search heading

### before
<img width="1167" alt="Screenshot 2022-06-29 at 10 27 52" src="https://user-images.githubusercontent.com/120181/176390163-85cc6283-a5f3-4608-8433-3df61ce72f2d.png">


### after

<img width="1072" alt="Screenshot 2022-06-29 at 10 26 42" src="https://user-images.githubusercontent.com/120181/176390176-b4ff4733-3daa-4bb4-8424-c007a5488643.png">
