### PR TITLE
[STAN-616] Add new footer links

### DIFF
--- a/ui/components/Layout/index.js
+++ b/ui/components/Layout/index.js
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import {
   Analytics,
   Breadcrumbs,
+  Flex,
   Navigation,
   PhaseBanner,
   Search,
@@ -103,51 +104,65 @@ export default function Home({ children, ...props }) {
         <div className="nhsuk-footer" id="nhsuk-footer">
           <div className="nhsuk-width-container">
             <h2 className="nhsuk-u-visually-hidden">Support links</h2>
-            <p className="nhsuk-footer__copyright">&copy; Crown copyright</p>
-            <ul className="nhsuk-footer__list">
-              <li className="nhsuk-footer__list-item">
-                <Link
-                  href="/accessibility-statement"
-                  className="nhsuk-footer__list-item-link"
-                >
-                  Accessibility statement
-                </Link>
-              </li>
-              <li className="nhsuk-footer__list-item">
-                <Link
-                  href="/cookie-policy"
-                  className="nhsuk-footer__list-item-link"
-                >
-                  Cookies
-                </Link>
-              </li>
-              <li className="nhsuk-footer__list-item">
-                <Link
-                  href="/privacy-policy"
-                  className="nhsuk-footer__list-item-link"
-                >
-                  Privacy
-                </Link>
-              </li>
-              <li className="nhsuk-footer__list-item">
-                <Link href="/site-map" className="nhsuk-footer__list-item-link">
-                  Site map
-                </Link>
-              </li>
-              <li className="nhsuk-footer__list-item">
-                <Link href="/about" className="nhsuk-footer__list-item-link">
-                  About this service
-                </Link>
-              </li>
-              <li className="nhsuk-footer__list-item">
-                <a
-                  className="nhsuk-footer__list-item-link"
-                  href="mailto:england.standards.directory@nhs.net"
-                >
-                  Contact: england.standards.directory@nhs.net
-                </a>
-              </li>
-            </ul>
+            <Flex>
+              <ul className="nhsuk-footer__list">
+                <li className="nhsuk-footer__list-item">
+                  <Link
+                    href="/accessibility-statement"
+                    className="nhsuk-footer__list-item-link"
+                  >
+                    Accessibility statement
+                  </Link>
+                </li>
+                <li className="nhsuk-footer__list-item">
+                  <Link
+                    href="/cookie-policy"
+                    className="nhsuk-footer__list-item-link"
+                  >
+                    Cookies
+                  </Link>
+                </li>
+                <li className="nhsuk-footer__list-item">
+                  <Link
+                    href="/privacy-policy"
+                    className="nhsuk-footer__list-item-link"
+                  >
+                    Privacy
+                  </Link>
+                </li>
+                <li className="nhsuk-footer__list-item">
+                  <Link
+                    href="/site-map"
+                    className="nhsuk-footer__list-item-link"
+                  >
+                    Site map
+                  </Link>
+                </li>
+                <li className="nhsuk-footer__list-item">
+                  <Link href="/about" className="nhsuk-footer__list-item-link">
+                    About this service
+                  </Link>
+                </li>
+                <li className="nhsuk-footer__list-item">
+                  <a
+                    className="nhsuk-footer__list-item-link"
+                    href="mailto:england.standards.directory@nhs.net"
+                  >
+                    Contact: england.standards.directory@nhs.net
+                  </a>
+                </li>
+              </ul>
+            </Flex>
+          </div>
+          <div className="nhsuk-width-container">
+            <p
+              className={classnames(
+                'nhsuk-footer__copyright',
+                styles.copyrightLink
+              )}
+            >
+              &copy; Crown copyright
+            </p>
           </div>
         </div>
       </footer>

--- a/ui/components/Layout/index.js
+++ b/ui/components/Layout/index.js
@@ -107,11 +107,45 @@ export default function Home({ children, ...props }) {
             <ul className="nhsuk-footer__list">
               <li className="nhsuk-footer__list-item">
                 <Link
+                  href="/accessibility-statement"
+                  className="nhsuk-footer__list-item-link"
+                >
+                  Accessibility statement
+                </Link>
+              </li>
+              <li className="nhsuk-footer__list-item">
+                <Link
                   href="/cookie-policy"
                   className="nhsuk-footer__list-item-link"
                 >
                   Cookies
                 </Link>
+              </li>
+              <li className="nhsuk-footer__list-item">
+                <Link
+                  href="/privacy-policy"
+                  className="nhsuk-footer__list-item-link"
+                >
+                  Privacy
+                </Link>
+              </li>
+              <li className="nhsuk-footer__list-item">
+                <Link href="/site-map" className="nhsuk-footer__list-item-link">
+                  Site map
+                </Link>
+              </li>
+              <li className="nhsuk-footer__list-item">
+                <Link href="/about" className="nhsuk-footer__list-item-link">
+                  About this service
+                </Link>
+              </li>
+              <li className="nhsuk-footer__list-item">
+                <a
+                  className="nhsuk-footer__list-item-link"
+                  href="mailto:england.standards.directory@nhs.net"
+                >
+                  Contact: england.standards.directory@nhs.net
+                </a>
               </li>
             </ul>
           </div>

--- a/ui/components/Layout/style.module.scss
+++ b/ui/components/Layout/style.module.scss
@@ -23,3 +23,10 @@
     padding-left: nhsuk-spacing(3);
   }
 }
+
+.copyrightLink {
+  float: left;
+  text-align: left;
+  padding-top: nhsuk-spacing(4);
+  color: #231f20;
+}


### PR DESCRIPTION
Adds in our new footer links

**mobile**

<img width="506" alt="Screenshot 2022-06-29 at 17 38 37" src="https://user-images.githubusercontent.com/120181/176478097-37182d89-8fb3-4e79-98f6-04b5bbb61b2a.png">


**tablet-ish**

<img width="756" alt="Screenshot 2022-06-29 at 17 38 28" src="https://user-images.githubusercontent.com/120181/176478100-443e57ef-883b-4215-b845-bc43509b82bf.png">


**desktop**

<img width="809" alt="Screenshot 2022-06-29 at 17 38 24" src="https://user-images.githubusercontent.com/120181/176478105-69c07274-50a6-4f9c-ab34-338913c7c9ae.png">
