### PR TITLE
[STAN-726] Switch filter summary markup for a11y

### DIFF
--- a/ui/components/FilterSummary/FilterSummary.module.scss
+++ b/ui/components/FilterSummary/FilterSummary.module.scss
@@ -8,7 +8,14 @@
 }
 
 .filterSection {
-  margin-bottom: $nhsuk-gutter;
+  margin-bottom: 0;
+  list-style: none;
+  padding-left: 0;
+
+  button {
+    padding: 10px 15px;
+    font-size: 16px;
+  }
 
   h4 {
     margin-bottom: $nhsuk-gutter / 2;

--- a/ui/components/FilterSummary/index.js
+++ b/ui/components/FilterSummary/index.js
@@ -7,9 +7,13 @@ import styles from './FilterSummary.module.scss';
 
 function Widget({ children, onClick }) {
   return (
-    <div onClick={onClick} className={styles.widget}>
+    <button
+      aria-label={`X, click to remove ${children}`}
+      onClick={onClick}
+      className={styles.widget}
+    >
       X {children}
-    </div>
+    </button>
   );
 }
 
@@ -47,21 +51,21 @@ export function FilterSummary({ schema }) {
           filters = [filters];
         }
         return (
-          <div key={key} className={styles.filterSection}>
+          <ul key={key} className={styles.filterSection}>
             {settings.label.toLowerCase() === 'type' && index >= 1 ? (
               <h4>In</h4>
             ) : null}
             {filters.map((filter, i) => {
               return (
-                <span key={i}>
+                <li key={i}>
                   {i > 0 && <span className={styles.and}>and</span>}
                   <Widget onClick={() => removeFilter(key, filter)}>
                     {filter}
                   </Widget>
-                </span>
+                </li>
               );
             })}
-          </div>
+          </ul>
         );
       })}
     </div>


### PR DESCRIPTION
- users can now tab into buttons to remove filters
- markup and aria labels based on https://weboverhauls.github.io/demos/chips/ 

### Tabbed selection state:
<img width="407" alt="Screenshot 2022-07-04 at 16 35 10" src="https://user-images.githubusercontent.com/120181/177175989-342033b8-62f2-4c43-b4ca-274ba1855a25.png">

### semantic markup
<img width="500" alt="Screenshot 2022-07-04 at 16 35 39" src="https://user-images.githubusercontent.com/120181/177175980-2aca20fd-408f-42b9-af8b-4c339093b9f7.png">

