### PR TITLE
[STAN-729] Change pagination to use Link component

### DIFF
--- a/ui/components/Pagination/index.js
+++ b/ui/components/Pagination/index.js
@@ -2,9 +2,10 @@ import classnames from 'classnames';
 import { Snippet } from '../';
 import styles from './style.module.scss';
 import { useQueryContext } from '../../context/query';
+import Link from 'next/link';
 
 export default function Pagination({ limit = 10, count }) {
-  const { query, updateQuery } = useQueryContext();
+  const { query, getRoute, getQuery } = useQueryContext();
   const page = parseInt(query.page, 10) || 1;
 
   const totalPages = Math.ceil(count / limit);
@@ -17,15 +18,21 @@ export default function Pagination({ limit = 10, count }) {
     return Array.from(Array(totalPages).keys()).slice(start, end);
   };
 
-  function goto(newPage) {
-    updateQuery({
-      ...query,
-      page: newPage,
-    });
-  }
+  const pageLink = (props) =>
+    [
+      getRoute(),
+      getQuery({
+        ...query,
+        ...props,
+      }),
+    ].join('?');
 
   return (
-    <div className={classnames('nhsuk-pagination', styles.pagination)}>
+    <nav
+      role="navigation"
+      aria-label="Pagination Navigation"
+      className={classnames('nhsuk-pagination', styles.pagination)}
+    >
       <div className={styles.summary}>
         <Snippet from={from} to={to} total={count} inline>
           pagination.summary
@@ -33,38 +40,67 @@ export default function Pagination({ limit = 10, count }) {
       </div>
       <ul>
         <li className={styles.item} id="prevButton">
-          <a
-            className={classnames(styles.link, {
-              [styles.current]: page <= 1,
-            })}
-            onClick={() => goto(page - 1)}
+          <Link
+            shallow={true}
+            href={
+              page <= 1
+                ? '#'
+                : pageLink({
+                    page: page - 1,
+                  })
+            }
           >
-            « Previous
-          </a>
+            <a
+              aria-label="Previous page"
+              className={classnames(styles.link, {
+                [styles.current]: page <= 1,
+              })}
+            >
+              « Previous
+            </a>
+          </Link>
         </li>
         {pagesToShow().map((num) => (
           <li className={styles.item} key={num}>
-            <a
-              className={classnames(styles.link, {
-                [styles.current]: page === num + 1,
+            <Link
+              shallow={true}
+              href={pageLink({
+                page: num + 1,
               })}
-              onClick={() => goto(num + 1)}
             >
-              {num + 1}
-            </a>
+              <a
+                aria-label={`Goto Page ${num + 1}`}
+                className={classnames(styles.link, {
+                  [styles.current]: page === num + 1,
+                })}
+              >
+                {num + 1}
+              </a>
+            </Link>
           </li>
         ))}
         <li className={styles.item} id="nextButton">
-          <a
-            className={classnames(styles.link, {
-              [styles.current]: page >= totalPages,
-            })}
-            onClick={() => goto(page + 1)}
+          <Link
+            shallow={true}
+            href={
+              page >= totalPages
+                ? '#'
+                : pageLink({
+                    page: page + 1,
+                  })
+            }
           >
-            Next »
-          </a>
+            <a
+              aria-label="Next page"
+              className={classnames(styles.link, {
+                [styles.current]: page >= totalPages,
+              })}
+            >
+              Next »
+            </a>
+          </Link>
         </li>
       </ul>
-    </div>
+    </nav>
   );
 }

--- a/ui/context/query.js
+++ b/ui/context/query.js
@@ -12,6 +12,10 @@ export function QueryContextWrapper({ children }) {
     return stringify({ ...query, ...props });
   }
 
+  function getRoute() {
+    return router.route;
+  }
+
   function getSelections() {
     return router.query;
   }
@@ -32,6 +36,7 @@ export function QueryContextWrapper({ children }) {
   const value = {
     query: router.query,
     getQuery,
+    getRoute,
     updateQuery,
     getSelections,
   };


### PR DESCRIPTION
- uses Next `<Link>` component and defers routing behaviour to Next
- generates anchor links with hrefs and aria labels, meaning keyboard
  navigation/tab focus is possible

### Tab focus
<img width="582" alt="Screenshot 2022-07-05 at 12 50 34" src="https://user-images.githubusercontent.com/120181/177312539-2a2e7a2f-5bbf-4cb0-828e-1e991f79794b.png">

<img width="546" alt="Screenshot 2022-07-05 at 12 50 39" src="https://user-images.githubusercontent.com/120181/177312533-cd9b0f53-9b2f-4d9b-b77f-7bd9dbdfc989.png">

