### PR TITLE
[STAN-731] fix misleading aria label

### DIFF
--- a/ui/components/Layout/index.js
+++ b/ui/components/Layout/index.js
@@ -40,7 +40,7 @@ export default function Home({ children, ...props }) {
                       'nhsuk-header__link nhsuk-header__link--service',
                       styles.logo
                     )}
-                    aria-label="NHS homepage"
+                    aria-label="NHS Standards Directory homepage"
                   >
                     <svg
                       className="nhsuk-logo"


### PR DESCRIPTION
See https://standardsportal.atlassian.net/browse/STAN-731 for details

The aria label suggested following the home link would send you back to the main nhs site. It doesn't, it sends you to the directory homepage. This PR updates the label to reflect that.