### PR TITLE
[STAN-770] set published standard boolean based on status

### DIFF
--- a/reader/lib/write/index.js
+++ b/reader/lib/write/index.js
@@ -26,10 +26,13 @@ const report = {
 
 const sleep = async (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+export const isPublished = (status) =>
+  ['active', 'deprecated', 'retired', 'draft'].includes(status) ? true : false;
+
 const writeRecord = async ({ record, headers, ckanUrl, dryRun } = {}) => {
   await sleep(150); //sleep .15s between hits to the api
 
-  const { title, reference_code } = record;
+  const { title, reference_code, status, is_published_standard } = record;
   // Slugify titles in a similar fashion to CKAN auto-slug
   const name = slugify(title, { lower: true, strict: true });
   console.log('\n * Processing record:\n  ', title);
@@ -38,6 +41,7 @@ const writeRecord = async ({ record, headers, ckanUrl, dryRun } = {}) => {
     ...{
       name,
       mandated: !!reference_code,
+      is_published_standard: is_published_standard || isPublished(status),
     },
   };
   let recordToWrite = params;


### PR DESCRIPTION
Added to set the `is_published_standard` based on status when no value for `is_published_standard` already exists.

Ran on dev back to dev like so:
```node write-json-to-ckan.js -f 'https://2gv8f9zmci.execute-api.eu-west-2.amazonaws.com/dev/get?key={key}&env=https://manage.dev.standards.nhs.uk/api/action' -w 'dev'```

We can now query records in dev by this value:

https://manage.dev.standards.nhs.uk/api/action/package_search?q=is_published_standard:true
123 published
https://manage.dev.standards.nhs.uk/api/action/package_search?q=is_published_standard:false
3 unpublished