### PR TITLE
[STAN-764] current page content

### DIFF
--- a/ui/components/Dataset/index.js
+++ b/ui/components/Dataset/index.js
@@ -34,7 +34,7 @@ function Model({ model }) {
     name,
     status,
     title,
-    metadata_modified,
+    metadata_created,
     standard_category,
     description,
   } = model;
@@ -63,7 +63,7 @@ function Model({ model }) {
         <p
           className={classnames('nhsuk-body-s', styles.right, styles.noBottom)}
         >
-          Last updated: {formatDate(metadata_modified)}
+          Added: {formatDate(metadata_created)}
         </p>
       </Flex>
     </>
@@ -85,12 +85,12 @@ function SortMenu({ searchTerm }) {
       value: 'score desc',
     },
     {
-      label: 'Updated (newest)',
-      value: 'metadata_modified desc',
+      label: 'Added (newest)',
+      value: 'metadata_created desc',
     },
     {
-      label: 'Updated (oldest)',
-      value: 'metadata_modified asc',
+      label: 'Added (oldest)',
+      value: 'metadata_created asc',
     },
     {
       label: 'A to Z',

--- a/ui/pages/standards/index.js
+++ b/ui/pages/standards/index.js
@@ -25,8 +25,8 @@ export default function Standards({ data, schemaData }) {
       <Reading>
         <Snippet>intro</Snippet>
         <p>
-          Explore all published data standards and information codes of practice
-          in England or view future standards.
+          Explore published standards and APIs used to format and exchange
+          healthcare data in England.
         </p>
       </Reading>
       <div className="nhsuk-grid-row">


### PR DESCRIPTION
Update current standards page as per [miro board](https://miro.com/app/board/uXjVOy1WyKs=/)

<img width="897" alt="Screenshot 2022-07-07 at 13 08 22" src="https://user-images.githubusercontent.com/120181/177759775-d55efff4-9e58-43c7-aa94-2f7032ea6562.png">
<img width="812" alt="Screenshot 2022-07-07 at 13 01 50" src="https://user-images.githubusercontent.com/120181/177759784-30774557-bc2b-4cee-9fff-9df40151685f.png">
<img width="211" alt="Screenshot 2022-07-07 at 13 01 45" src="https://user-images.githubusercontent.com/120181/177759786-81011051-3fd2-4988-9987-376334933304.png">


Please note this does not include `Type` => `Standard type` update! This requires a ckan schema change, which will come separately.