### PR TITLE
[STAN-768] standards listings and status tags

### DIFF
--- a/ui/components/Dataset/index.js
+++ b/ui/components/Dataset/index.js
@@ -52,13 +52,13 @@ function Model({ model }) {
       </p>
       <Flex className="nhsuk-body-s">
         <p className={classnames('nhsuk-body-s', styles.noBottom)}>
-          Type:{' '}
-          <Tag type={standard_category} classes="nhsuk-body-s">
-            {standard_category}
-          </Tag>
+          Type: {standard_category}
         </p>
         <p className={classnames('nhsuk-body-s', styles.noBottom)}>
-          Status: {upperFirst(status)}
+          Status:{' '}
+          <Tag type={status} classes="nhsuk-body-s">
+            {upperFirst(status)}
+          </Tag>
         </p>
         <p
           className={classnames('nhsuk-body-s', styles.right, styles.noBottom)}

--- a/ui/components/ReviewDates/index.js
+++ b/ui/components/ReviewDates/index.js
@@ -4,17 +4,10 @@ import format from 'date-fns/format';
 const date = (val) => format(parseISO(val), 'dd MMMM yyyy');
 
 export default function ReviewDates({ data }) {
-  const {
-    // metadata_created,
-    metadata_modified,
-  } = data;
+  const { metadata_modified } = data;
   return (
     <p className="nhsuk-body-s nhsuk-u-secondary-text-color nhsuk-u-margin-top-7 nhsuk-u-margin-bottom-0 nhsuk-u-font-size-16 secondary-text">
-      {/* Page created: {date(metadata_created)} */}
-      {/* <br /> */}
-      Page last reviewed: {date(metadata_modified)}
-      <br />
-      Next review due: 25 November 2022
+      Page last updated: {date(metadata_modified)}
     </p>
   );
 }

--- a/ui/components/Tag/index.js
+++ b/ui/components/Tag/index.js
@@ -1,19 +1,19 @@
 import classnames from 'classnames';
 
-const typeMap = {
-  'technical standards and specifications': 'nhsuk-tag--blue',
-  'information codes of practice': 'nhsuk-tag--red',
-  'record standard': 'nhsuk-tag--orange',
-  'data definitions and terminologies': 'nhsuk-tag--green',
-};
+// const typeMap = {
+//   'technical standards and specifications': 'nhsuk-tag--blue',
+//   'information codes of practice': 'nhsuk-tag--red',
+//   'record standard': 'nhsuk-tag--orange',
+//   'data definitions and terminologies': 'nhsuk-tag--green',
+// };
 
 export default function TypeTag({ children, classes, type }) {
   return (
     <span
       className={classnames(
         'nhsuk-tag',
-        classes,
-        typeMap[type.toLowerCase()] || null
+        classes
+        // typeMap[type.toLowerCase()] || null
       )}
     >
       {children}

--- a/ui/components/Tag/index.js
+++ b/ui/components/Tag/index.js
@@ -1,19 +1,22 @@
 import classnames from 'classnames';
 
-// const typeMap = {
-//   'technical standards and specifications': 'nhsuk-tag--blue',
-//   'information codes of practice': 'nhsuk-tag--red',
-//   'record standard': 'nhsuk-tag--orange',
-//   'data definitions and terminologies': 'nhsuk-tag--green',
-// };
+const colorMap = {
+  active: 'nhsuk-tag--green',
+  deprecated: 'nhsuk-tag--orange',
+  retired: 'nhsuk-tag--red',
+  draft: 'nhsuk-tag--grey',
+  // proposed: 'nhsuk-tag--grey',
+  // awaiting: 'nhsuk-tag--grey',
+  // discontinued: 'nhsuk-tag--grey',
+};
 
 export default function TypeTag({ children, classes, type }) {
   return (
     <span
       className={classnames(
         'nhsuk-tag',
-        classes
-        // typeMap[type.toLowerCase()] || null
+        classes,
+        colorMap[type.toLowerCase()] || null
       )}
     >
       {children}

--- a/ui/schema/index.js
+++ b/ui/schema/index.js
@@ -13,7 +13,7 @@ const schema = [
       label: 'Status',
       format: (val) => (
         <>
-          {upperFirst(val)}
+          <Tag type={val}>{upperFirst(val)}</Tag>
           {
             <Details
               className="nhsuk-u-font-size-16 nhsuk-u-margin-top-4"
@@ -46,7 +46,7 @@ const schema = [
       label: 'Type',
       format: (val) => (
         <>
-          <Tag type={val}>{val}</Tag>
+          {val}
           {
             <Details
               className="nhsuk-u-font-size-16 nhsuk-u-margin-top-4"


### PR DESCRIPTION
- Status now wrapped in `<Tag>` component
- Tag removed from type
- Next review date removed

<img width="545" alt="Screenshot 2022-07-07 at 14 07 02" src="https://user-images.githubusercontent.com/120181/177769440-25360360-4523-4a63-95c6-c25ddb38c8aa.png">
<img width="829" alt="Screenshot 2022-07-07 at 14 02 21" src="https://user-images.githubusercontent.com/120181/177769446-f801bf8b-68bd-4dc3-955a-97a7cafef254.png">
<img width="805" alt="Screenshot 2022-07-07 at 14 01 02" src="https://user-images.githubusercontent.com/120181/177769451-d9090f5c-0069-48f0-b2a7-571f17a2448e.png">
<img width="811" alt="Screenshot 2022-07-07 at 14 00 55" src="https://user-images.githubusercontent.com/120181/177769452-fb6d682a-48a5-4ad0-82b8-212c3f34d66c.png">
<img width="536" alt="Screenshot 2022-07-07 at 13 51 02" src="https://user-images.githubusercontent.com/120181/177769453-495920fe-2dba-4bc2-b921-35fe4a9c786b.png">
<img width="716" alt="Screenshot 2022-07-07 at 13 50 47" src="https://user-images.githubusercontent.com/120181/177769454-1c96e26b-d740-409e-bb43-27e64a90017f.png">
