### PR TITLE
[STAN-734] switch from tables to description lists

### DIFF
--- a/ui/components/Model/index.js
+++ b/ui/components/Model/index.js
@@ -1,5 +1,6 @@
 import get from 'lodash/get';
-import { Table, Tbody, Tr, Td } from '../';
+import classnames from 'classnames';
+import styles from './style.module.scss';
 
 const format = ({ options, vals, data }) =>
   options.format ? options.format(vals, data) : vals;
@@ -7,7 +8,7 @@ const format = ({ options, vals, data }) =>
 const Rows = (props) => {
   const { options, vals, data } = props;
   return (
-    <Td>
+    <dd>
       {Array.isArray(vals) && vals.length > 0 ? (
         <ul className="nhsuk-list-bullet nhsuk-u-font-size-16">
           {vals.map((val, index) => (
@@ -19,36 +20,34 @@ const Rows = (props) => {
       ) : (
         format(props)
       )}
-    </Td>
+    </dd>
   );
 };
 
 const Section = ({ entry, data }) => {
   return (
     <>
-      <h2 className="nhsuk-heading-m">{entry.section_title}</h2>
-      <Table>
-        <Tbody>
-          {Object.keys(entry)
-            .filter((key) => entry[key].label)
-            .map((key, index) => {
-              const options = entry[key];
-              const val = options.accessor
-                ? get(data, options.accessor, data[key])
-                : data[key];
-              return (
-                <Tr key={index}>
-                  <Td>
-                    <span className="nhsuk-u-font-weight-bold">
-                      {options.label}
-                    </span>
-                  </Td>
-                  <Rows vals={val} options={options} data={data}></Rows>
-                </Tr>
-              );
-            })}
-        </Tbody>
-      </Table>
+      <h2 className={classnames(styles.sectionTitle, 'nhsuk-heading-m')}>
+        {entry.section_title}
+      </h2>
+      {Object.keys(entry)
+        .filter((key) => entry[key].label)
+        .map((key, index) => {
+          const options = entry[key];
+          const val = options.accessor
+            ? get(data, options.accessor, data[key])
+            : data[key];
+          return (
+            <dl key={index} className={classnames(styles.grid)}>
+              <dt>
+                <span className="nhsuk-u-font-weight-bold">
+                  {options.label}
+                </span>
+              </dt>
+              <Rows vals={val} options={options} data={data}></Rows>
+            </dl>
+          );
+        })}
     </>
   );
 };

--- a/ui/components/Model/style.module.scss
+++ b/ui/components/Model/style.module.scss
@@ -1,0 +1,18 @@
+@import 'vars';
+
+.grid {
+  display: grid;
+  grid-template-columns: 2fr 6fr;
+  gap: 10px;
+  padding: 16px 0;
+  margin: 5px 0 0;
+  @include borderBottom($light-grey);
+
+  * {
+    font-size: 16px;
+  }
+}
+
+.sectionTitle {
+  margin-top: $nhsuk-gutter * 2;
+}

--- a/ui/cypress/integration/standards/list.js
+++ b/ui/cypress/integration/standards/list.js
@@ -46,7 +46,7 @@ describe('Standards Listing Index', () => {
 
         cy.get('#browse-results li a').eq(0).click();
 
-        cy.contains('td', 'Professional Record Standards Body');
+        cy.contains('dd', 'Professional Record Standards Body');
       });
 
       it('Matches various variations of prsb', () => {
@@ -55,14 +55,14 @@ describe('Standards Listing Index', () => {
 
         cy.get('#browse-results li a').eq(0).click();
 
-        cy.contains('td', 'Professional Record Standards Body');
+        cy.contains('dd', 'Professional Record Standards Body');
 
         cy.visit('/standards');
         cy.doSearch('professional records standards body');
         cy.get('#browse-results li a').eq(0).click({
           force: true,
         });
-        cy.contains('td', 'Professional Record Standards Body');
+        cy.contains('dd', 'Professional Record Standards Body');
       });
 
       it('Matches various variations of nhs', () => {
@@ -71,21 +71,21 @@ describe('Standards Listing Index', () => {
 
         cy.get('#browse-results li a').eq(0).click();
 
-        cy.contains('td', 'NHS Digital');
+        cy.contains('dd', 'NHS Digital');
 
         cy.visit('/standards');
 
         cy.doSearch('nhsx');
         cy.get('#browse-results li a').eq(0).click();
 
-        cy.contains('td', 'NHS Digital');
+        cy.contains('dd', 'NHS Digital');
 
         cy.visit('/standards');
 
         cy.doSearch('nhs digital');
         cy.get('#browse-results li a').eq(0).click();
 
-        cy.contains('td', 'NHS Digital');
+        cy.contains('dd', 'NHS Digital');
       });
     });
   });


### PR DESCRIPTION
Before: 

use of tables, accessibility sad:
<img width="1072" alt="Screenshot 2022-07-22 at 15 45 27" src="https://user-images.githubusercontent.com/120181/180452478-74fc9cc0-75ca-45fa-aabf-b1621a1198f1.png">


After:
Use data lists/definitions organised by grid, accessibility less sad:
<img width="1072" alt="Screenshot 2022-07-22 at 15 45 02" src="https://user-images.githubusercontent.com/120181/180452581-620b35bd-f55e-46f1-8d83-2b047a3fd7f4.png">


The layout and style should be almost identical between builds, though there is less markup in use now. 

Aside: we can likely remove our `Table, Thead, Tbody, Tr, Td` components now
