### PR TITLE
[STAN-829] Add cypress-axe, check a11y in one test

### DIFF
--- a/ui/cypress/e2e/standards/list.cy.js
+++ b/ui/cypress/e2e/standards/list.cy.js
@@ -1,3 +1,5 @@
+import { a11yLog } from '../../support/custom';
+
 describe('Standards Listing Index', () => {
   it('should accesss standards listing page', () => {
     cy.visit(`/standards`);
@@ -13,8 +15,11 @@ describe('Standards Listing Index', () => {
   describe('Search', () => {
     it('Can search by standard matching', () => {
       cy.visit('/standards');
+      cy.injectAxe();
       cy.doSearch('allergies');
       cy.get('#browse-results li').not('have.length', 0);
+      // cy.checkA11y(context, options, violationCallback, skipFailures);
+      cy.checkA11y(null, null, a11yLog, true);
     });
 
     it('Can search by fuzzy match', () => {

--- a/ui/cypress/plugins/index.js
+++ b/ui/cypress/plugins/index.js
@@ -19,6 +19,21 @@
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
+  on('task', {
+    log(message) {
+      // eslint-disable-next-line no-console
+      console.log(message);
+
+      return null;
+    },
+    table(message) {
+      // eslint-disable-next-line no-console
+      console.table(message);
+
+      return null;
+    },
+  });
+
   config.baseUrl = process.env.BASE_URL || config.baseUrl;
 
   return config;

--- a/ui/cypress/support/custom.js
+++ b/ui/cypress/support/custom.js
@@ -10,12 +10,15 @@ const impactMap = {
 export function a11yLog(violations) {
   cy.task(
     'log',
-    `${violations.length} accessibility violation${
+    `
+    ${violations.length} accessibility violation${
       violations.length === 1 ? '' : 's'
-    } ${violations.length === 1 ? 'was' : 'were'} detected`
+    } ${violations.length === 1 ? 'was' : 'were'} detected
+    `
   );
-  cy.task('log', 'violeations', violations);
-  cy.task('log', 'noeds', violations.nodes);
+
+  // Uncomment to log out all violations
+  // cy.task('log',  violations);
 
   // pluck specific keys to keep the table readable
   const violationData = violations.map(

--- a/ui/cypress/support/custom.js
+++ b/ui/cypress/support/custom.js
@@ -1,0 +1,38 @@
+const impactMap = {
+  minor: 'minor 🟡',
+  moderate: 'moderate 🟠',
+  serious: 'serious 🔴',
+  critical: 'critical 🔥',
+};
+
+// From https://github.com/component-driven/cypress-axe
+// Define at the top of the spec file or just import it
+export function a11yLog(violations) {
+  cy.task(
+    'log',
+    `${violations.length} accessibility violation${
+      violations.length === 1 ? '' : 's'
+    } ${violations.length === 1 ? 'was' : 'were'} detected`
+  );
+  cy.task('log', 'violeations', violations);
+  cy.task('log', 'noeds', violations.nodes);
+
+  // pluck specific keys to keep the table readable
+  const violationData = violations.map(
+    ({
+      id,
+      impact,
+      description,
+      // nodes,
+      helpUrl,
+    }) => ({
+      id,
+      impact: impactMap[impact],
+      description,
+      //   nodes: nodes.length,
+      helpUrl,
+    })
+  );
+
+  cy.task('table', violationData);
+}

--- a/ui/cypress/support/e2e.js
+++ b/ui/cypress/support/e2e.js
@@ -18,3 +18,7 @@ import './commands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+// Accessibility testing
+// https://github.com/component-driven/cypress-axe
+import 'cypress-axe';

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -27,7 +27,9 @@
       "devDependencies": {
         "@babel/preset-env": "^7.17.12",
         "@babel/preset-react": "^7.17.12",
+        "axe-core": "^4.4.3",
         "cypress": "^10.3.1",
+        "cypress-axe": "^1.0.0",
         "eslint": "7.32.0",
         "eslint-config-next": "11.1.2",
         "eslint-config-prettier": "^8.5.0",
@@ -3658,12 +3660,12 @@
       "dev": true
     },
     "node_modules/axe-core": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.2.tgz",
-      "integrity": "sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
+      "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
       "dev": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=4"
       }
     },
     "node_modules/axios": {
@@ -4520,6 +4522,19 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/cypress-axe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-1.0.0.tgz",
+      "integrity": "sha512-QBlNMAd5eZoyhG8RGGR/pLtpHGkvgWXm2tkP68scJ+AjYiNNOlJihxoEwH93RT+rWOLrefw4iWwEx8kpEcrvJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "axe-core": "^3 || ^4",
+        "cypress": "^10"
       }
     },
     "node_modules/cypress/node_modules/ansi-styles": {
@@ -15393,9 +15408,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.2.tgz",
-      "integrity": "sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
+      "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
       "dev": true
     },
     "axios": {
@@ -16106,6 +16121,13 @@
           }
         }
       }
+    },
+    "cypress-axe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-1.0.0.tgz",
+      "integrity": "sha512-QBlNMAd5eZoyhG8RGGR/pLtpHGkvgWXm2tkP68scJ+AjYiNNOlJihxoEwH93RT+rWOLrefw4iWwEx8kpEcrvJA==",
+      "dev": true,
+      "requires": {}
     },
     "damerau-levenshtein": {
       "version": "1.0.8",

--- a/ui/package.json
+++ b/ui/package.json
@@ -33,7 +33,9 @@
   "devDependencies": {
     "@babel/preset-env": "^7.17.12",
     "@babel/preset-react": "^7.17.12",
+    "axe-core": "^4.4.3",
     "cypress": "^10.3.1",
+    "cypress-axe": "^1.0.0",
     "eslint": "7.32.0",
     "eslint-config-next": "11.1.2",
     "eslint-config-prettier": "^8.5.0",


### PR DESCRIPTION
* Adds cypress-axe for a11y testing
* Adds support for logging advisories to a table
* Skips failures for now.

A11y advice looks like this:
<img width="1494" alt="Screenshot 2022-07-27 at 15 23 46" src="https://user-images.githubusercontent.com/120181/181258051-d143b7ff-0884-40a8-9097-3edbebe14256.png">

