### PR TITLE
[STAN-829] add some automated accessibility tests

### DIFF
--- a/ui/components/Filters/index.js
+++ b/ui/components/Filters/index.js
@@ -104,7 +104,7 @@ export default function Filters({ schema }) {
 
   return (
     <div className="nhsuk-filters">
-      <h3>Filters</h3>
+      <h2 className="nhsuk-heading-m">Filters</h2>
       <div className="nhsuk-expander-group">
         {filters.map((filter) => {
           let fieldFilters = activeFilters[filter.field_name] || [];

--- a/ui/components/Layout/index.js
+++ b/ui/components/Layout/index.js
@@ -79,25 +79,21 @@ export default function Home({ children, ...props }) {
           </Row>
         </div>
         <Navigation />
-        <PhaseBanner />
       </header>
 
-      <Breadcrumbs
-        labels={{
-          standards: 'Current standards',
-          content: 'Browse content standards',
-          technical: 'Browse technical standards',
-          services: 'Browse services',
-        }}
-      />
-
-      {props.Hero && <props.Hero {...props} />}
-
-      <div className="nhsuk-width-container">
-        <main className={styles.main} id="maincontent" role="main">
-          {children}
-        </main>
-      </div>
+      <main className={styles.main} id="maincontent" role="main">
+        <PhaseBanner homepage={props.homepage} />
+        {props.Hero && <props.Hero {...props} />}
+        <Breadcrumbs
+          labels={{
+            standards: 'Current standards',
+            content: 'Browse content standards',
+            technical: 'Browse technical standards',
+            services: 'Browse services',
+          }}
+        />
+        <div className="nhsuk-width-container">{children}</div>
+      </main>
 
       <footer role="contentinfo">
         <div className="nhsuk-footer" id="nhsuk-footer">

--- a/ui/components/Layout/index.js
+++ b/ui/components/Layout/index.js
@@ -79,6 +79,7 @@ export default function Home({ children, ...props }) {
           </Row>
         </div>
         <Navigation />
+        <PhaseBanner />
       </header>
 
       <Breadcrumbs
@@ -89,8 +90,6 @@ export default function Home({ children, ...props }) {
           services: 'Browse services',
         }}
       />
-
-      <PhaseBanner homepage={props.homepage} />
 
       {props.Hero && <props.Hero {...props} />}
 

--- a/ui/components/Layout/style.module.scss
+++ b/ui/components/Layout/style.module.scss
@@ -4,7 +4,6 @@
 @import 'node_modules/nhsuk-frontend/packages/components/header/_header.scss';
 
 .main {
-  padding-top: $nhsuk-gutter;
   padding-bottom: $nhsuk-gutter * 2;
 }
 

--- a/ui/components/PhaseBanner/index.js
+++ b/ui/components/PhaseBanner/index.js
@@ -2,33 +2,19 @@ import classnames from 'classnames';
 import styles from './style.module.scss';
 import Link from '../Link';
 
-export default function PhaseBanner({ homepage }) {
+export default function PhaseBanner() {
   return (
-    <div
-      className={classnames('nhsuk-phase-banner', styles.phaseBanner, {
-        [styles.homepage]: homepage,
-      })}
-    >
-      <div
-        className={classnames('nhsuk-width-container', styles.inner, {
-          [styles.homepage]: homepage,
-        })}
-      >
+    <div className={classnames('nhsuk-phase-banner', styles.phaseBanner)}>
+      <div className={classnames('nhsuk-width-container', styles.inner)}>
         <span className="nhsuk-u-font-size-14">
-          <strong
-            className={classnames('nhsuk-tag', styles.tag, {
-              [styles.homepage]: homepage,
-            })}
-          >
+          <strong className={classnames('nhsuk-tag', styles.tag)}>
             {' '}
             BETA{' '}
           </strong>
           <span className="nhsuk-phase-banner__text">
             This is a new service — your{' '}
             <Link
-              className={classnames('nhsuk-phase-banner', styles.bannerLink, {
-                [styles.homepage]: homepage,
-              })}
+              className={classnames('nhsuk-phase-banner', styles.bannerLink)}
               href="https://forms.gle/CKKi5nFzUjuxHB9N6"
               newWindow={true}
               text="feedback"

--- a/ui/components/PhaseBanner/index.js
+++ b/ui/components/PhaseBanner/index.js
@@ -2,19 +2,33 @@ import classnames from 'classnames';
 import styles from './style.module.scss';
 import Link from '../Link';
 
-export default function PhaseBanner() {
+export default function PhaseBanner({ homepage }) {
   return (
-    <div className={classnames('nhsuk-phase-banner', styles.phaseBanner)}>
-      <div className={classnames('nhsuk-width-container', styles.inner)}>
+    <div
+      className={classnames('nhsuk-phase-banner', styles.phaseBanner, {
+        [styles.homepage]: homepage,
+      })}
+    >
+      <div
+        className={classnames('nhsuk-width-container', styles.inner, {
+          [styles.homepage]: homepage,
+        })}
+      >
         <span className="nhsuk-u-font-size-14">
-          <strong className={classnames('nhsuk-tag', styles.tag)}>
+          <strong
+            className={classnames('nhsuk-tag', styles.tag, {
+              [styles.homepage]: homepage,
+            })}
+          >
             {' '}
             BETA{' '}
           </strong>
           <span className="nhsuk-phase-banner__text">
             This is a new service — your{' '}
             <Link
-              className={classnames('nhsuk-phase-banner', styles.bannerLink)}
+              className={classnames('nhsuk-phase-banner', styles.bannerLink, {
+                [styles.homepage]: homepage,
+              })}
               href="https://forms.gle/CKKi5nFzUjuxHB9N6"
               newWindow={true}
               text="feedback"

--- a/ui/components/PhaseBanner/style.module.scss
+++ b/ui/components/PhaseBanner/style.module.scss
@@ -33,5 +33,8 @@
 .bannerLink {
   &.homepage {
     color: white;
+    &:focus {
+      color: black;
+    }
   }
 }

--- a/ui/components/PhaseBanner/style.module.scss
+++ b/ui/components/PhaseBanner/style.module.scss
@@ -2,16 +2,22 @@
 @import 'node_modules/nhsuk-frontend/packages/core/settings/_colours.scss';
 
 .phaseBanner {
-  background-color: $blue;
+  &.homepage {
+    background-color: $blue;
+  }
 }
 
 .inner {
   padding-top: $nhsuk-gutter-smaller;
   padding-bottom: $nhsuk-gutter-smaller;
+
   @include borderBottom;
-  @include borderTop(rgba(255, 255, 255, 0.2));
-  border-bottom: 0;
-  color: $white;
+
+  &.homepage {
+    @include borderTop(rgba(255, 255, 255, 0.2));
+    border-bottom: 0;
+    color: $white;
+  }
 }
 
 .tag {
@@ -19,11 +25,13 @@
   background-color: $color_nhsuk-blue;
   border: none;
   margin-right: $nhsuk-gutter-smaller;
-  border: 1px solid white;
+
+  &.homepage {
+    border: 1px solid white;
+  }
 }
 .bannerLink {
-  color: white;
-  &:visited {
+  &.homepage {
     color: white;
   }
 }

--- a/ui/components/PhaseBanner/style.module.scss
+++ b/ui/components/PhaseBanner/style.module.scss
@@ -2,22 +2,16 @@
 @import 'node_modules/nhsuk-frontend/packages/core/settings/_colours.scss';
 
 .phaseBanner {
-  &.homepage {
-    background-color: $blue;
-  }
+  background-color: $blue;
 }
 
 .inner {
   padding-top: $nhsuk-gutter-smaller;
   padding-bottom: $nhsuk-gutter-smaller;
-
   @include borderBottom;
-
-  &.homepage {
-    @include borderTop(rgba(255, 255, 255, 0.2));
-    border-bottom: 0;
-    color: $white;
-  }
+  @include borderTop(rgba(255, 255, 255, 0.2));
+  border-bottom: 0;
+  color: $white;
 }
 
 .tag {
@@ -25,17 +19,11 @@
   background-color: $color_nhsuk-blue;
   border: none;
   margin-right: $nhsuk-gutter-smaller;
-
-  &.homepage {
-    border: 1px solid white;
-  }
+  border: 1px solid white;
 }
 .bannerLink {
-  &.homepage {
+  color: white;
+  &:visited {
     color: white;
-    &:hover {
-      background-color: $color_transparent_nhsuk-blue-50;
-      color: white;
-    }
   }
 }

--- a/ui/components/Search/style.module.scss
+++ b/ui/components/Search/style.module.scss
@@ -5,11 +5,17 @@
 .searchFormInNavWrapper {
   float: right;
   margin-right: $nhsuk-gutter;
-  margin-bottom: $nhsuk-gutter;
+  // margin-bottom: $nhsuk-gutter;
+  margin-bottom: 0;
+  line-height: 0.5;
 }
 
 .search {
   position: relative;
+}
+
+.searchLabel {
+  margin-bottom: 0;
 }
 
 .searchInNav {

--- a/ui/cypress/e2e/home.cy.js
+++ b/ui/cypress/e2e/home.cy.js
@@ -1,3 +1,5 @@
+import { a11yLog, failLevel } from '../support/custom';
+
 describe('Homepage', () => {
   it('should show home page and call to action', () => {
     cy.visit('/');
@@ -25,6 +27,17 @@ describe('Homepage', () => {
       cy.visit('/');
       cy.doSearch(' ');
       cy.get('#browse-results li').not('have.length', 0);
+    });
+  });
+
+  describe('a11y', () => {
+    it('has sufficient contrast on focussed links', () => {
+      cy.visit('/');
+      cy.injectAxe();
+      cy.get('.nhsuk-phase-banner__text a').focus();
+      cy.checkA11y(null, null, a11yLog, failLevel);
+      cy.get('#recent-standards a').first().focus();
+      cy.checkA11y(null, null, a11yLog, failLevel);
     });
   });
 });

--- a/ui/cypress/e2e/standards/list.cy.js
+++ b/ui/cypress/e2e/standards/list.cy.js
@@ -1,5 +1,7 @@
 import { a11yLog } from '../../support/custom';
 
+const failOn = ['moderate', 'serious', 'critical'];
+
 describe('Standards Listing Index', () => {
   it('should accesss standards listing page', () => {
     cy.visit(`/standards`);
@@ -18,8 +20,8 @@ describe('Standards Listing Index', () => {
       cy.injectAxe();
       cy.doSearch('allergies');
       cy.get('#browse-results li').not('have.length', 0);
-      // cy.checkA11y(context, options, violationCallback, skipFailures);
-      cy.checkA11y(null, null, a11yLog, true);
+
+      cy.checkA11y(null, null, a11yLog, failOn);
     });
 
     it('Can search by fuzzy match', () => {

--- a/ui/cypress/e2e/standards/list.cy.js
+++ b/ui/cypress/e2e/standards/list.cy.js
@@ -1,6 +1,4 @@
-import { a11yLog } from '../../support/custom';
-
-const failOn = ['moderate', 'serious', 'critical'];
+import { a11yLog, failLevel } from '../../support/custom';
 
 describe('Standards Listing Index', () => {
   it('should accesss standards listing page', () => {
@@ -21,7 +19,7 @@ describe('Standards Listing Index', () => {
       cy.doSearch('allergies');
       cy.get('#browse-results li').not('have.length', 0);
 
-      cy.checkA11y(null, null, a11yLog, failOn);
+      cy.checkA11y(null, null, a11yLog, failLevel);
     });
 
     it('Can search by fuzzy match', () => {

--- a/ui/cypress/e2e/standards/standard-page.cy.js
+++ b/ui/cypress/e2e/standards/standard-page.cy.js
@@ -1,6 +1,11 @@
+import { a11yLog } from '../../support/custom';
+const failOn = ['serious', 'critical'];
+
 describe('Standards', () => {
   it('should be able to access a content standards model', () => {
     cy.visit('/standards/about-me');
     cy.contains('h1', 'About Me');
+    cy.injectAxe();
+    cy.checkA11y(null, null, a11yLog, failOn);
   });
 });

--- a/ui/cypress/support/custom.js
+++ b/ui/cypress/support/custom.js
@@ -21,21 +21,27 @@ export function a11yLog(violations) {
   // cy.task('log',  violations);
 
   // pluck specific keys to keep the table readable
-  const violationData = violations.map(
-    ({
-      id,
-      impact,
-      description,
-      // nodes,
-      helpUrl,
-    }) => ({
-      id,
-      impact: impactMap[impact],
-      description,
-      //   nodes: nodes.length,
-      helpUrl,
-    })
-  );
+  const violationData = violations
+    .map(
+      ({
+        id,
+        impact,
+        description,
+        nodes,
+        // helpUrl
+      }) => ({
+        id,
+        impact: impactMap[impact],
+        description,
+        nodes: nodes[0].target,
+        // helpUrl,
+      })
+    )
+    // set console table index to be the error id, not 0,1,2 etc
+    .reduce((acc, { id, ...violation }) => {
+      acc[id] = violation;
+      return acc;
+    }, {});
 
   cy.task('table', violationData);
 }

--- a/ui/cypress/support/custom.js
+++ b/ui/cypress/support/custom.js
@@ -5,6 +5,8 @@ const impactMap = {
   critical: 'critical 🔥',
 };
 
+export const failLevel = ['serious', 'critical'];
+
 // From https://github.com/component-driven/cypress-axe
 // Define at the top of the spec file or just import it
 export function a11yLog(violations) {

--- a/ui/cypress/support/e2e.js
+++ b/ui/cypress/support/e2e.js
@@ -21,4 +21,4 @@ import './commands';
 
 // Accessibility testing
 // https://github.com/component-driven/cypress-axe
-import 'cypress-axe';
+import '@-ralph/cypress-axe';

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -25,11 +25,11 @@
         "urlencoded-body-parser": "^3.0.0"
       },
       "devDependencies": {
+        "@-ralph/cypress-axe": "^1.0.0-rc",
         "@babel/preset-env": "^7.17.12",
         "@babel/preset-react": "^7.17.12",
         "axe-core": "^4.4.3",
         "cypress": "^10.3.1",
-        "cypress-axe": "^1.0.0",
         "eslint": "7.32.0",
         "eslint-config-next": "11.1.2",
         "eslint-config-prettier": "^8.5.0",
@@ -41,6 +41,19 @@
         "prettier": "^2.6.2",
         "pretty-quick": "^3.1.3",
         "sass": "^1.43.2"
+      }
+    },
+    "node_modules/@-ralph/cypress-axe": {
+      "version": "1.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@-ralph/cypress-axe/-/cypress-axe-1.0.0-rc.tgz",
+      "integrity": "sha512-EtqXszt0EOiFlMQcwrQTmq26Td5B1OHSY8lxRdcuz5vNBmS7YucyPqjU31AgNTGcj8RDljsJYoj3gC8ZrFQ3GA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "axe-core": "^3 || ^4",
+        "cypress": "^10"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4522,19 +4535,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/cypress-axe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-1.0.0.tgz",
-      "integrity": "sha512-QBlNMAd5eZoyhG8RGGR/pLtpHGkvgWXm2tkP68scJ+AjYiNNOlJihxoEwH93RT+rWOLrefw4iWwEx8kpEcrvJA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "axe-core": "^3 || ^4",
-        "cypress": "^10"
       }
     },
     "node_modules/cypress/node_modules/ansi-styles": {
@@ -12802,6 +12802,13 @@
     }
   },
   "dependencies": {
+    "@-ralph/cypress-axe": {
+      "version": "1.0.0-rc",
+      "resolved": "https://registry.npmjs.org/@-ralph/cypress-axe/-/cypress-axe-1.0.0-rc.tgz",
+      "integrity": "sha512-EtqXszt0EOiFlMQcwrQTmq26Td5B1OHSY8lxRdcuz5vNBmS7YucyPqjU31AgNTGcj8RDljsJYoj3gC8ZrFQ3GA==",
+      "dev": true,
+      "requires": {}
+    },
     "@ampproject/remapping": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
@@ -16121,13 +16128,6 @@
           }
         }
       }
-    },
-    "cypress-axe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-1.0.0.tgz",
-      "integrity": "sha512-QBlNMAd5eZoyhG8RGGR/pLtpHGkvgWXm2tkP68scJ+AjYiNNOlJihxoEwH93RT+rWOLrefw4iWwEx8kpEcrvJA==",
-      "dev": true,
-      "requires": {}
     },
     "damerau-levenshtein": {
       "version": "1.0.8",

--- a/ui/package.json
+++ b/ui/package.json
@@ -31,11 +31,11 @@
     "urlencoded-body-parser": "^3.0.0"
   },
   "devDependencies": {
+    "@-ralph/cypress-axe": "^1.0.0-rc",
     "@babel/preset-env": "^7.17.12",
     "@babel/preset-react": "^7.17.12",
     "axe-core": "^4.4.3",
     "cypress": "^10.3.1",
-    "cypress-axe": "^1.0.0",
     "eslint": "7.32.0",
     "eslint-config-next": "11.1.2",
     "eslint-config-prettier": "^8.5.0",

--- a/ui/styles/Home.module.scss
+++ b/ui/styles/Home.module.scss
@@ -11,6 +11,9 @@
   padding: 2em 2em 1em;
   a {
     color: white;
+    &:focus {
+      color: black;
+    }
   }
 }
 
@@ -50,6 +53,9 @@
 }
 
 .homeSection {
+  &:first-child {
+    padding-top: 2 * $nhsuk-gutter;
+  }
   hr {
     border: 2px solid $nhsuk-border-color;
   }


### PR DESCRIPTION
* adds some additional tests for accessibility, using my [port of the cypress-axe package](https://www.npmjs.com/package/@-ralph/cypress-axe)
* Reorders headings in search page 

### Banner change
* One of our a11y failures was that the `phaseBanner` was free floating
  outside of a landmark pieces of html, e.g. `<header>` or `<main>`
* Here I'm moving the `<PhaseBanner>` into the `<main>` section in order that
  screen readers know which part of the site it's in
  https://dequeuniversity.com/rules/axe/4.4/region?application=axeAPI
* Also fixes a header bounce from the search styling — the header
  maintains the same shape whether it has a search bar in it or not now
* consistent with the markup in e.g. test and trace https://enquiries.test-and-trace.nhs.uk/national-guidance?t=1659096472610 

#### Before
<img width="1036" alt="Screenshot 2022-07-29 at 15 24 31" src="https://user-images.githubusercontent.com/120181/181769893-10e7218b-982d-4da2-a9b1-38b2a38ef956.png">


#### After
<img width="1019" alt="Screenshot 2022-07-29 at 14 35 44" src="https://user-images.githubusercontent.com/120181/181769938-77cac4cd-041a-4fa8-a3e8-d40ec6a73d8a.png">

### Link contrast [STAN-735](https://standardsportal.atlassian.net/browse/STAN-735)

* adds a fix (and a test!) for link contrast on the homepage
<img width="378" alt="Screenshot 2022-07-29 at 15 30 15" src="https://user-images.githubusercontent.com/120181/181771849-e0e3e419-097f-47e7-b5a1-6f51c7b4f276.png">
<img width="234" alt="Screenshot 2022-07-29 at 15 30 12" src="https://user-images.githubusercontent.com/120181/181771855-f2ba622a-c8fd-494b-8c63-4611af7af753.png">

