### PR TITLE
[STAN-739] Give additional description for "In" filter summary

### DIFF
--- a/ui/components/FilterSummary/index.js
+++ b/ui/components/FilterSummary/index.js
@@ -56,7 +56,14 @@ export function FilterSummary({ schema }) {
           const isType = settings.label.toLowerCase() === 'standard type';
           return (
             <>
-              {isType && index >= 1 ? <h4>In</h4> : null}
+              {isType && index >= 1 ? (
+                <h4>
+                  <span className="nhsuk-u-visually-hidden">
+                    The filters selected are inside this type
+                  </span>
+                  In
+                </h4>
+              ) : null}
               {filters.map((filter, i) => {
                 return (
                   <li key={i}>


### PR DESCRIPTION
From the accessibility report:

> When the select element options is changed to ‘Information codes of practice’ a new heading is present on the page titled ‘In’ which is ambiguous. It provides no meaningful information for blind users and is not descriptive of what it describes.

> Current code ref(s): #maincontent > div:nth-child(4) > div.nhsuk-grid-column-three-quarters > div.FilterSummary_filterSummary__blpzH > div:nth-child(2) > h4

```<h4 data-element-id="headingsMap-4" data-headingsmap-highlight="true">In</h4>```

Solution:

We recommend providing some hidden text situated within the heading to give blind users more context on the purpose of the heading.