### PR TITLE
[STAN-738] give role=status to results span

### DIFF
--- a/ui/components/Dataset/index.js
+++ b/ui/components/Dataset/index.js
@@ -165,14 +165,7 @@ const NoResultsSummary = ({ searchTerm }) => (
 const ResultSummary = ({ count, searchTerm, filtersSelected, loading }) => (
   <h2 id="resultSummary" data-loading={loading}>
     {(loading && 'Searching for results') || (
-      <Snippet
-        num={count}
-        plural={count > 1 || count === 0}
-        searchTerm={searchTerm}
-        inline
-      >
-        {searchTerm || filtersSelected ? 'filters.summary' : 'filters.all'}
-      </Snippet>
+      <span role="status">{`${count} result${count === 1 ? '' : 's'}`}</span>
     )}
   </h2>
 );

--- a/ui/components/Dataset/index.js
+++ b/ui/components/Dataset/index.js
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { useState, useEffect } from 'react';
-import { Snippet, Tag, Flex, Pagination, FilterSummary, Select } from '../';
+import { Tag, Flex, Pagination, FilterSummary, Select } from '../';
 import upperFirst from 'lodash/upperFirst';
 import format from 'date-fns/format';
 import parseISO from 'date-fns/parseISO';
@@ -162,7 +162,7 @@ const NoResultsSummary = ({ searchTerm }) => (
   </>
 );
 
-const ResultSummary = ({ count, searchTerm, filtersSelected, loading }) => (
+const ResultSummary = ({ count, loading }) => (
   <h2 id="resultSummary" data-loading={loading}>
     {(loading && 'Searching for results') || (
       <span role="status">{`${count} result${count === 1 ? '' : 's'}`}</span>

--- a/ui/context/content.js
+++ b/ui/context/content.js
@@ -3,10 +3,6 @@ import merge from 'lodash/merge';
 
 const CONTENT = {
   title: 'NHS Standards Directory',
-  filters: {
-    summary: '{{num}} result{{#plural}}s{{/plural}}',
-    all: '{{num}} result{{#plural}}s{{/plural}}',
-  },
   pagination: {
     summary: 'Showing {{from}} - {{to}} of {{total}} results',
   },


### PR DESCRIPTION
* Stops using `Snippet`, which was generating odd markup `<h3 id="resultSummary" data-loading="false"><span index="0" node="[object Object]">29 results</span></h3>`
* Remove call to content context
* add `role="status"` to results count span

<img width="218" alt="Screenshot 2022-07-29 at 16 55 51" src="https://user-images.githubusercontent.com/120181/181788279-7e3d5e8c-779c-4878-954a-70125515a32f.png">

<img width="234" alt="Screenshot 2022-07-29 at 16 55 47" src="https://user-images.githubusercontent.com/120181/181788280-c5c84983-9022-42d2-bf7f-b8792ab417e8.png">

<img width="717" alt="Screenshot 2022-07-29 at 16 56 02" src="https://user-images.githubusercontent.com/120181/181788276-e6d28ea9-d220-4852-8571-95cff2aa15ad.png">

