### PR TITLE
[STAN-739] add description to browse heading

### DIFF
--- a/ui/pages/standards/index.js
+++ b/ui/pages/standards/index.js
@@ -21,7 +21,12 @@ export default function Standards({ data, schemaData }) {
     : 'Current standards';
   return (
     <Page title={setPageTitle(pageTitle)}>
-      <h1>{pageTitle}</h1>
+      <h1>
+        {pageTitle}
+        <span className="nhsuk-u-visually-hidden">
+          Search or browse published standards
+        </span>
+      </h1>
       <Reading>
         <Snippet>intro</Snippet>
         <p>


### PR DESCRIPTION
Responding to concerns in our accessibility review that the current heading is not descriptive.

> The heading ‘Published standards’ does not provide enough descriptive information to convey the purpose of the content it is introducing.
> “While exploring the heading structure of the page using the Quick Nav ‘h’ command, I observed that although the filters were provided with their own heading, the search feature itself was not introduced in this way.