### PR TITLE
removed upcoming standards

### DIFF
--- a/ui/helpers/api.js
+++ b/ui/helpers/api.js
@@ -10,6 +10,10 @@ export function queriseSelections(selections) {
   if (!selections) return;
 
   for (const prop in selections) {
+    if (typeof selections[prop] === 'boolean') {
+      query[prop] = selectionsRef[prop];
+      continue;
+    }
     if (typeof selections[prop] === 'string') {
       selectionsRef[prop] = [selectionsRef[prop]];
     }
@@ -94,6 +98,8 @@ export async function list({ page = 1, q, sort, filters }) {
         .join(', ');
     }
   }
+
+  filters.is_published_standard = true;
 
   fq = serialise(queriseSelections(filters));
 

--- a/ui/helpers/api.js
+++ b/ui/helpers/api.js
@@ -99,6 +99,10 @@ export async function list({ page = 1, q, sort, filters }) {
     }
   }
 
+  if (!filters) {
+    filters = {};
+  }
+
   filters.is_published_standard = true;
 
   fq = serialise(queriseSelections(filters));


### PR DESCRIPTION
Upcoming standards are for the roadmap and should be filtered from the main list of published standards. This code exists in roadmap branch, but needs to be pushed first as data now includes unpublished standards