### PR TITLE
[STAN-869] Add google analytics

### DIFF
--- a/ui/components/Analytics/index.js
+++ b/ui/components/Analytics/index.js
@@ -2,25 +2,10 @@ import Script from 'next/script';
 import { getCookie } from 'cookies-next';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
+import { pageview } from '../../helpers/gtag';
 
 export const GA_TRACKING_ID = process.env.NEXT_PUBLIC_TRACKING_ID;
 export const GA_TAG_ID = process.env.NEXT_PUBLIC_TAG_ID;
-
-// https://developers.google.com/analytics/devguides/collection/gtagjs/pages
-export const pageview = (url) => {
-  window.gtag('config', GA_TAG_ID, {
-    page_path: url,
-  });
-};
-
-// https://developers.google.com/analytics/devguides/collection/gtagjs/events
-export const event = ({ action, category, label, value }) => {
-  window.gtag('event', action, {
-    event_category: category,
-    event_label: label,
-    value: value,
-  });
-};
 
 export function Analytics() {
   const router = useRouter();

--- a/ui/components/Analytics/index.js
+++ b/ui/components/Analytics/index.js
@@ -11,7 +11,7 @@ export function Analytics() {
   const router = useRouter();
   useEffect(() => {
     const handleRouteChange = (url) => {
-      pageview(url);
+      pageview(url, GA_TRACKING_ID);
     };
     router.events.on('routeChangeComplete', handleRouteChange);
     return () => {

--- a/ui/components/Analytics/index.js
+++ b/ui/components/Analytics/index.js
@@ -1,0 +1,84 @@
+import Script from 'next/script';
+import { getCookie } from 'cookies-next';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+export const GA_TRACKING_ID = process.env.NEXT_PUBLIC_TRACKING_ID;
+export const GA_TAG_ID = process.env.NEXT_PUBLIC_TAG_ID;
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+export const pageview = (url) => {
+  window.gtag('config', GA_TAG_ID, {
+    page_path: url,
+  });
+};
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/events
+export const event = ({ action, category, label, value }) => {
+  window.gtag('event', action, {
+    event_category: category,
+    event_label: label,
+    value: value,
+  });
+};
+
+export function Analytics() {
+  const router = useRouter();
+  useEffect(() => {
+    const handleRouteChange = (url) => {
+      pageview(url);
+    };
+    router.events.on('routeChangeComplete', handleRouteChange);
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange);
+    };
+  }, [router.events]);
+
+  const consentChoice = getCookie('localConsent');
+  return (
+    <>
+      {/* Global Site Tag (gtag.js) - Google Analytics */}
+      <Script
+        strategy="afterInteractive"
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
+      />
+
+      <Script
+        id="gtag"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{
+          __html: `
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+
+            gtag('consent', 'default', {
+              'ad_storage': 'denied',
+              'analytics_storage': 'denied'
+            });
+
+
+            (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+                      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+                      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+                      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+                      })(window,document,'script','dataLayer','${GA_TAG_ID}');`,
+        }}
+      />
+
+      {consentChoice === true && (
+        <Script
+          id="consupd"
+          strategy="afterInteractive"
+          dangerouslySetInnerHTML={{
+            __html: `
+          gtag('consent', 'update', {
+            'ad_storage': 'granted',
+            'analytics_storage': 'granted'
+          });
+        `,
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/ui/components/Analytics/style.module.scss
+++ b/ui/components/Analytics/style.module.scss
@@ -1,0 +1,24 @@
+@import 'vars';
+
+.banner {
+  background: white;
+  position: relative;
+  box-shadow: 0 0 4px 0 #212b32;
+  padding: 24px 0 19px;
+  width: 100%;
+
+  button {
+    margin-bottom: $nhsuk-gutter;
+  }
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.listItem {
+  display: inline;
+  margin-right: $nhsuk-gutter * 2;
+}

--- a/ui/components/Cookies/index.js
+++ b/ui/components/Cookies/index.js
@@ -2,26 +2,40 @@ import { useEffect, useState } from 'react';
 import { setCookie, hasCookie } from 'cookies-next';
 import classnames from 'classnames';
 import styles from './style.module.scss';
+import ReactGA from 'react-ga4';
 
-// import { useRouter } from 'next/router';
-// import ReactGA from 'react-ga4';
-
-export const Cookies = () => {
-  // const router = useRouter();
-
+export const Cookies = ({ choice }) => {
+  const [consentChoice, setConsentChoice] = useState(choice);
   useEffect(() => {
     setConsentChoice(hasCookie('localConsent'));
-  }, []);
+  }, [choice]);
 
-  const [consentChoice, setConsentChoice] = useState(true);
+  // console.log(consentChoice, setConsentChoice);
+
+  if (consentChoice === true) {
+    // console.log(
+    //   'should be initialising',
+    //   process.env.NEXT_PUBLIC_TRACKING_ID,
+    //   ReactGA
+    // );
+    ReactGA.initialize([
+      {
+        trackingId: process.env.NEXT_PUBLIC_TRACKING_ID,
+        // gaOptions: {...}, // optional
+        // gtagOptions: {...}, // optional
+      },
+    ]);
+    ReactGA.send('pageview');
+    ReactGA.send('pageview');
+  }
 
   const handleCookies = (choice) => {
-    setConsentChoice(true);
+    setConsentChoice(choice);
     setCookie('localConsent', choice, { maxAge: 60 * 60 * 24 * 365 });
   };
 
   return (
-    !consentChoice && (
+    (!consentChoice && (
       <div id="nhsuk-cookie-banner" data-nosnippet="true">
         <div
           className={classnames('nhsuk-cookie-banner', styles.banner)}
@@ -68,32 +82,7 @@ export const Cookies = () => {
           </div>
         </div>
       </div>
-    )
+    )) ||
+    null
   );
 };
-
-// useEffect(() => {
-//   if (!process.env.NEXT_PUBLIC_TRACKING_ID) {
-//     return null;
-//   }
-//   // https://www.npmjs.com/package/react-ga4
-//   ReactGA.initialize([
-//     {
-//       trackingId: process.env.NEXT_PUBLIC_TRACKING_ID,
-//       gaOptions: {}, // optional
-//       gtagOptions: {}, // optional
-//     },
-//     // {
-//     //   trackingId: 'your second GA measurement id',
-//     // },
-//   ]);
-
-//   const handleRouteChange = (url) => {
-//     if (process.env.NODE_ENV === 'production') {
-//       ReactGA.send({ hitType: 'pageview', page: url });
-//     }
-//   };
-//   router.events.on('routeChangeComplete', handleRouteChange);
-
-//   return () => router.events.off('routeChangeComplete', handleRouteChange);
-// }, [router]);

--- a/ui/components/Cookies/index.js
+++ b/ui/components/Cookies/index.js
@@ -2,32 +2,12 @@ import { useEffect, useState } from 'react';
 import { setCookie, hasCookie } from 'cookies-next';
 import classnames from 'classnames';
 import styles from './style.module.scss';
-import ReactGA from 'react-ga4';
 
 export const Cookies = ({ choice }) => {
   const [consentChoice, setConsentChoice] = useState(choice);
   useEffect(() => {
     setConsentChoice(hasCookie('localConsent'));
   }, [choice]);
-
-  // console.log(consentChoice, setConsentChoice);
-
-  if (consentChoice === true) {
-    // console.log(
-    //   'should be initialising',
-    //   process.env.NEXT_PUBLIC_TRACKING_ID,
-    //   ReactGA
-    // );
-    ReactGA.initialize([
-      {
-        trackingId: process.env.NEXT_PUBLIC_TRACKING_ID,
-        // gaOptions: {...}, // optional
-        // gtagOptions: {...}, // optional
-      },
-    ]);
-    ReactGA.send('pageview');
-    ReactGA.send('pageview');
-  }
 
   const handleCookies = (choice) => {
     setConsentChoice(choice);

--- a/ui/components/Layout/index.js
+++ b/ui/components/Layout/index.js
@@ -2,6 +2,7 @@ import { useRouter } from 'next/router';
 import Head from 'next/head';
 import Link from 'next/link';
 import {
+  Analytics,
   Cookies,
   Breadcrumbs,
   Flex,
@@ -30,6 +31,7 @@ export default function Home({ children, ...props }) {
   return (
     <div className={styles.container}>
       <Head>
+        {/* <Analytics /> */}
         <title>{title}</title>
         <link rel="icon" href="/favicon.png" />
       </Head>

--- a/ui/components/Layout/index.js
+++ b/ui/components/Layout/index.js
@@ -31,10 +31,10 @@ export default function Home({ children, ...props }) {
   return (
     <div className={styles.container}>
       <Head>
-        {/* <Analytics /> */}
         <title>{title}</title>
         <link rel="icon" href="/favicon.png" />
       </Head>
+      <Analytics />
       <a className="nhsuk-skip-link" href="#maincontent">
         Skip to main content
       </a>

--- a/ui/components/index.js
+++ b/ui/components/index.js
@@ -1,3 +1,4 @@
+export { Analytics } from './Analytics';
 export { Cookies } from './Cookies';
 export { default as Breadcrumbs } from './Breadcrumbs';
 export { default as Card } from './Card';

--- a/ui/helpers/gtag.js
+++ b/ui/helpers/gtag.js
@@ -1,0 +1,16 @@
+// https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+export const pageview = (url) => {
+  console.log('trying to send', url, GA_TRACKING_ID);
+  window.gtag('config', GA_TRACKING_ID, {
+    page_path: url,
+  });
+};
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/events
+export const event = ({ action, category, label, value }) => {
+  window.gtag('event', action, {
+    event_category: category,
+    event_label: label,
+    value: value,
+  });
+};

--- a/ui/helpers/gtag.js
+++ b/ui/helpers/gtag.js
@@ -1,7 +1,6 @@
 // https://developers.google.com/analytics/devguides/collection/gtagjs/pages
-export const pageview = (url) => {
-  console.log('trying to send', url, GA_TRACKING_ID);
-  window.gtag('config', GA_TRACKING_ID, {
+export const pageview = (url, trackingId) => {
+  window.gtag('config', trackingId, {
     page_path: url,
   });
 };

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -22,7 +22,6 @@
         "node-fetch": "^3.1.0",
         "react": "17.0.2",
         "react-dom": "17.0.2",
-        "react-ga4": "^1.4.1",
         "react-markdown": "^6.0.3",
         "urlencoded-body-parser": "^3.0.0"
       },
@@ -11057,11 +11056,6 @@
         "react": "17.0.2"
       }
     },
-    "node_modules/react-ga4": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-1.4.1.tgz",
-      "integrity": "sha512-ioBMEIxd4ePw4YtaloTUgqhQGqz5ebDdC4slEpLgy2sLx1LuZBC9iYCwDymTXzcntw6K1dHX183ulP32nNdG7w=="
-    },
     "node_modules/react-is": {
       "version": "18.1.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
@@ -20743,11 +20737,6 @@
         "object-assign": "^4.1.1",
         "scheduler": "^0.20.2"
       }
-    },
-    "react-ga4": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-1.4.1.tgz",
-      "integrity": "sha512-ioBMEIxd4ePw4YtaloTUgqhQGqz5ebDdC4slEpLgy2sLx1LuZBC9iYCwDymTXzcntw6K1dHX183ulP32nNdG7w=="
     },
     "react-is": {
       "version": "18.1.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -28,7 +28,6 @@
     "node-fetch": "^3.1.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "react-ga4": "^1.4.1",
     "react-markdown": "^6.0.3",
     "urlencoded-body-parser": "^3.0.0"
   },


### PR DESCRIPTION
Google analytics is initialised on page load, but it requires a `localConsent` cookie in order to start logging to our google tag container.

### before consent given

<img width="903" alt="Screenshot 2022-08-23 at 16 50 44" src="https://user-images.githubusercontent.com/120181/186191420-727e638e-57aa-418b-8122-3724fe2fd740.png">

### after consent given

Additional tracking cookie set

<img width="903" alt="Screenshot 2022-08-23 at 16 51 42" src="https://user-images.githubusercontent.com/120181/186191548-81e55549-9a1d-43d3-90c3-4ba4358ecd08.png">

### google analytics debugger output


Showing consent being set and pageview events firing


<img width="903" alt="Screenshot 2022-08-23 at 16 52 35" src="https://user-images.githubusercontent.com/120181/186191898-10f16026-dd58-441c-9bd2-1a34edb3495b.png">

