### PR TITLE
Bugfix - query string expected in different format

### DIFF
--- a/ui/components/Pagination/index.js
+++ b/ui/components/Pagination/index.js
@@ -5,7 +5,7 @@ import { useQueryContext } from '../../context/query';
 import Link from 'next/link';
 
 export default function Pagination({ limit = 10, count }) {
-  const { query, getRoute, getQuery } = useQueryContext();
+  const { query, getRoute, updateQuery } = useQueryContext();
   const page = parseInt(query.page, 10) || 1;
 
   const totalPages = Math.ceil(count / limit);
@@ -18,14 +18,17 @@ export default function Pagination({ limit = 10, count }) {
     return Array.from(Array(totalPages).keys()).slice(start, end);
   };
 
-  const pageLink = (props) =>
-    [
-      getRoute(),
-      getQuery({
-        ...query,
-        ...props,
-      }),
-    ].join('?');
+  const pageLink = (props) => {
+    return {
+      pathname: getRoute(),
+      query: { ...query, ...props },
+    };
+  };
+
+  const changePage = (page) => (e) => {
+    e.preventDefault();
+    updateQuery({ ...query, page });
+  };
 
   return (
     <nav
@@ -55,6 +58,7 @@ export default function Pagination({ limit = 10, count }) {
               className={classnames(styles.link, {
                 [styles.current]: page <= 1,
               })}
+              onClick={changePage(page - 1)}
             >
               « Previous
             </a>
@@ -73,6 +77,7 @@ export default function Pagination({ limit = 10, count }) {
                 className={classnames(styles.link, {
                   [styles.current]: page === num + 1,
                 })}
+                onClick={changePage(num + 1)}
               >
                 {num + 1}
               </a>
@@ -95,6 +100,7 @@ export default function Pagination({ limit = 10, count }) {
               className={classnames(styles.link, {
                 [styles.current]: page >= totalPages,
               })}
+              onClick={changePage(page + 1)}
             >
               Next »
             </a>

--- a/ui/context/query.js
+++ b/ui/context/query.js
@@ -1,7 +1,6 @@
 import { useRouter } from 'next/router';
 import { createContext, useContext } from 'react';
 import { pickBy } from 'lodash';
-import { stringify } from 'qs';
 
 const QueryContext = createContext();
 
@@ -10,7 +9,7 @@ export function QueryContextWrapper({ children }) {
 
   function getQuery(props) {
     const { query } = router;
-    return stringify({ ...query, ...props });
+    return new URLSearchParams({ ...query, ...props });
   }
 
   function getRoute() {


### PR DESCRIPTION
* Next.js doesn't handle key[]=a,key[]=b formatting from qs.stringify, it requries arrays to be in the format key=a,key=b
* Updated pagination to generate href in correct format (using object href)
* Updated pagination to use ajax progressive enhancement
* Updated query string helper to use URLSearchParams in place of qs.stringify