### PR TITLE
[STAN-869] Add in Analytics tags for test and prod builds

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -37,6 +37,19 @@ jobs:
           password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         env:
           AWS_REGION: ${{ env.AWS_REGION }}
+      - name: build and push
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
+          ECR_REPOSITORY: nhsx-standards-directory
+          IMAGE_TAG: ui-production-${{ github.sha }}
+          GOOGLE_TAG_ID: ${{ secrets.GOOGLE_TAG_ID }}
+          TRACKING_ID: ${{ secrets.TRACKING_ID }}
+        run: |
+          # Build a docker container and push it to ECR
+          docker build --build-arg NEXT_PUBLIC_TAG_ID=$GOOGLE_TAG_ID --build-arg NEXT_PUBLIC_TRACKING_ID=$TRACKING_ID -t $ECR_REPOSITORY:$IMAGE_TAG .
+          docker tag $ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
       - name: deploy
         uses: koslib/helm-eks-action@master
         env:
@@ -112,6 +125,6 @@ jobs:
           SLACK_CHANNEL: developers
           SLACK_COLOR: good
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_TITLE: "prod deployment: succeeded"
-          SLACK_MESSAGE: ":+1::rocket:"
-          MSG_MINIMAL: "true"
+          SLACK_TITLE: 'prod deployment: succeeded'
+          SLACK_MESSAGE: ':+1::rocket:'
+          MSG_MINIMAL: 'true'

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -37,10 +37,22 @@ jobs:
           password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         env:
           AWS_REGION: ${{ env.AWS_REGION }}
+      - name: build and push
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
+          ECR_REPOSITORY: nhsx-standards-directory
+          IMAGE_TAG: ui-test-${{ github.sha }}
+          GOOGLE_TAG_ID: ${{ secrets.GOOGLE_TAG_ID }}
+          TRACKING_ID: ${{ secrets.TRACKING_ID }}
+        run: |
+          # Build a docker container and push it to ECR
+          docker build --build-arg NEXT_PUBLIC_TAG_ID=$GOOGLE_TAG_ID --build-arg NEXT_PUBLIC_TRACKING_ID=$TRACKING_ID -t $ECR_REPOSITORY:$IMAGE_TAG .
+          docker tag $ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
       - name: UI deploy
         uses: koslib/helm-eks-action@master
         env:
-          # AWS_REGION: ${{ env.AWS_REGION }}
           AWS_REGION: eu-west-2
           KUBE_CONFIG_DATA: ${{ secrets.KUBECONFIG_FILE }}
           ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}


### PR DESCRIPTION
* We build a docker image for each deployment again
* This is so we can set different build args for each environment
  * this allows different analytics ids per env
* docker image tags reference their environment e.g.
```
IMAGE_TAG: ui-production-${{ github.sha }}
```