### PR TITLE
[STAN-940] Add reusable workflow for deploying the UI

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -33,47 +33,7 @@ jobs:
       - run: npx serverless config credentials --provider aws --key ${{ secrets.SERVERLESS_AWS_ACCESS_KEY_ID }} --secret ${{ secrets.SERVERLESS_AWS_SECRET_ACCESS_KEY }} --profile k8sDev
       - run: npx serverless deploy --aws-profile=k8sDev --verbose --debug=*
 
-  build-ui-container:
-    runs-on: ubuntu-latest
-    environment: dev
-    defaults:
-      run:
-        working-directory: ui
-    env:
-      AWS_REGION: eu-west-2
-    steps:
-      - name: checkout
-        uses: actions/checkout@v2
-      - name: configure credentials (using us-east-1)
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-      - name: Login to Public ECR
-        uses: docker/login-action@v1
-        with:
-          registry: public.ecr.aws
-          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        env:
-          AWS_REGION: ${{ env.AWS_REGION }}
-      - name: build and push
-        id: build-image
-        env:
-          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
-          ECR_REPOSITORY: nhsx-standards-directory
-          IMAGE_TAG: ui-${{ github.sha }}
-          GOOGLE_TAG_ID: ${{ secrets.GOOGLE_TAG_ID }}
-          TRACKING_ID: ${{ secrets.TRACKING_ID }}
-        run: |
-          # Build a docker container and push it to ECR
-          docker build --build-arg NEXT_PUBLIC_TAG_ID=$GOOGLE_TAG_ID --build-arg NEXT_PUBLIC_TRACKING_ID=$TRACKING_ID -t $ECR_REPOSITORY:$IMAGE_TAG .
-          docker tag $ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-
   deploy-ui:
-    needs: build-ui-container
     uses: nhsx/standards-registry/.github/workflows/helm-deploy-ui.yml@STAN-940/templated-builds
     with:
       app_name: dev-ui

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,19 +1,15 @@
 name: deploy-dev
-# TODO: move all helm jobs to shared workflow
-# ui
-# ckan
-# Put correct spec for running job back in
+
 on:
-  - push
-  # workflow_run:
-  #   branches:
-  #     - master
-  #   workflows:
-  #     - build-and-test
-  #   types:
-  #     - completed
-  #   conclusion:
-  #     - success
+  workflow_run:
+    branches:
+      - master
+    workflows:
+      - deploy-test
+    types:
+      - completed
+    conclusion:
+      - success
 
 jobs:
   deploy-csv-exporter:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -30,7 +30,7 @@ jobs:
       - run: npx serverless deploy --aws-profile=k8sDev --verbose --debug=*
 
   deploy-ui:
-    uses: nhsx/standards-registry/.github/workflows/helm-deploy-ui.yml@STAN-940/templated-builds
+    uses: nhsx/standards-registry/.github/workflows/helm-deploy-ui.yml@master
     with:
       environment: dev
     secrets:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -36,7 +36,6 @@ jobs:
   deploy-ui:
     uses: nhsx/standards-registry/.github/workflows/helm-deploy-ui.yml@STAN-940/templated-builds
     with:
-      app_name: dev-ui
       environment: dev
     secrets:
       ckan_url: ${{ secrets.CKAN_URL }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -33,7 +33,7 @@ jobs:
       - run: npx serverless config credentials --provider aws --key ${{ secrets.SERVERLESS_AWS_ACCESS_KEY_ID }} --secret ${{ secrets.SERVERLESS_AWS_SECRET_ACCESS_KEY }} --profile k8sDev
       - run: npx serverless deploy --aws-profile=k8sDev --verbose --debug=*
 
-  ui:
+  build-ui-container:
     runs-on: ubuntu-latest
     environment: dev
     defaults:
@@ -73,7 +73,7 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
   deploy-ui:
-    needs: ui
+    needs: build-ui-container
     uses: nhsx/standards-registry/.github/workflows/helm-deploy-ui.yml@STAN-940/templated-builds
     with:
       app_name: dev-ui
@@ -84,22 +84,8 @@ jobs:
       google_tag_id: ${{ secrets.GOOGLE_TAG_ID }}
       ecr_registry: ${{ secrets.ECR_REGISTRY }}
       kubeconfig_file: ${{ secrets.KUBECONFIG_FILE }}
-      # - name: deploy
-      #   uses: koslib/helm-eks-action@master
-      #   env:
-      #     KUBE_CONFIG_DATA: ${{ secrets.KUBECONFIG_FILE }}
-      #     ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
-      #     ECR_REPOSITORY: nhsx-standards-directory
-      #     IMAGE_TAG: ui-${{ github.sha }}
-      #     PAGES_CKAN_URL: 'https://manage.test.standards.nhs.uk/api/action'
-      #   with:
-      #     command: >-
-      #       helm upgrade --install --wait -n dev ui ./charts/ui
-      #       --set ui.config.ckanurl='${{ secrets.CKAN_URL }}'
-      #       --set ui.config.tracking_id='${{ secrets.TRACKING_ID }}'
-      #       --set ui.config.google_tag_id='${{ secrets.GOOGLE_TAG_ID }}'
-      #       --set ui.container.image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-      #       --set ui.config.pagesckanurl=$PAGES_CKAN_URL
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   ckan:
     runs-on: ubuntu-latest
@@ -163,7 +149,7 @@ jobs:
   integrationtest:
     if: ${{ success() }}
     needs:
-      - ui
+      - deploy-ui
       - ckan
       - deploy-csv-exporter
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,15 +1,19 @@
 name: deploy-dev
-
+# TODO: move all helm jobs to shared workflow
+# ui
+# ckan
+# Put correct spec for running job back in
 on:
-  workflow_run:
-    branches:
-      - master
-    workflows:
-      - build-and-test
-    types:
-      - completed
-    conclusion:
-      - success
+  - push
+  # workflow_run:
+  #   branches:
+  #     - master
+  #   workflows:
+  #     - build-and-test
+  #   types:
+  #     - completed
+  #   conclusion:
+  #     - success
 
 jobs:
   deploy-csv-exporter:
@@ -67,22 +71,35 @@ jobs:
           docker build --build-arg NEXT_PUBLIC_TAG_ID=$GOOGLE_TAG_ID --build-arg NEXT_PUBLIC_TRACKING_ID=$TRACKING_ID -t $ECR_REPOSITORY:$IMAGE_TAG .
           docker tag $ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-      - name: deploy
-        uses: koslib/helm-eks-action@master
-        env:
-          KUBE_CONFIG_DATA: ${{ secrets.KUBECONFIG_FILE }}
-          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
-          ECR_REPOSITORY: nhsx-standards-directory
-          IMAGE_TAG: ui-${{ github.sha }}
-          PAGES_CKAN_URL: 'https://manage.test.standards.nhs.uk/api/action'
-        with:
-          command: >-
-            helm upgrade --install --wait -n dev ui ./charts/ui
-            --set ui.config.ckanurl='${{ secrets.CKAN_URL }}'
-            --set ui.config.tracking_id='${{ secrets.TRACKING_ID }}'
-            --set ui.config.google_tag_id='${{ secrets.GOOGLE_TAG_ID }}'
-            --set ui.container.image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-            --set ui.config.pagesckanurl=$PAGES_CKAN_URL
+
+  deploy-ui:
+    needs: ui
+    uses: nhsx/standards-registry/.github/workflows/helm-deploy-ui.yml@STAN-940/templated-builds
+    with:
+      app_name: dev-ui
+      environment: dev
+    secrets:
+      ckan_url: ${{ secrets.CKAN_URL }}
+      tracking_id: ${{ secrets.TRACKING_ID }}
+      google_tag_id: ${{ secrets.GOOGLE_TAG_ID }}
+      ecr_registry: ${{ secrets.ECR_REGISTRY }}
+      kubeconfig_file: ${{ secrets.KUBECONFIG_FILE }}
+      # - name: deploy
+      #   uses: koslib/helm-eks-action@master
+      #   env:
+      #     KUBE_CONFIG_DATA: ${{ secrets.KUBECONFIG_FILE }}
+      #     ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
+      #     ECR_REPOSITORY: nhsx-standards-directory
+      #     IMAGE_TAG: ui-${{ github.sha }}
+      #     PAGES_CKAN_URL: 'https://manage.test.standards.nhs.uk/api/action'
+      #   with:
+      #     command: >-
+      #       helm upgrade --install --wait -n dev ui ./charts/ui
+      #       --set ui.config.ckanurl='${{ secrets.CKAN_URL }}'
+      #       --set ui.config.tracking_id='${{ secrets.TRACKING_ID }}'
+      #       --set ui.config.google_tag_id='${{ secrets.GOOGLE_TAG_ID }}'
+      #       --set ui.container.image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+      #       --set ui.config.pagesckanurl=$PAGES_CKAN_URL
 
   ckan:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   deploy-ui:
-    uses: nhsx/standards-registry/.github/workflows/helm-deploy-ui.yml@STAN-940/templated-builds
+    uses: nhsx/standards-registry/.github/workflows/helm-deploy-ui.yml@master
     with:
       environment: prod
     secrets:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -12,60 +12,19 @@ on:
       - success
 
 jobs:
-  ui:
-    runs-on: ubuntu-latest
-    environment: prod
-    defaults:
-      run:
-        working-directory: ui
-    env:
-      AWS_REGION: eu-west-2
-    steps:
-      - name: checkout
-        uses: actions/checkout@v2
-      - name: configure credentials (using us-east-1)
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-      - name: Login to Public ECR
-        uses: docker/login-action@v1
-        with:
-          registry: public.ecr.aws
-          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        env:
-          AWS_REGION: ${{ env.AWS_REGION }}
-      - name: build and push
-        id: build-image
-        env:
-          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
-          ECR_REPOSITORY: nhsx-standards-directory-prod
-          IMAGE_TAG: ui-${{ github.sha }}
-          GOOGLE_TAG_ID: ${{ secrets.GOOGLE_TAG_ID }}
-          TRACKING_ID: ${{ secrets.TRACKING_ID }}
-        run: |
-          # Build a docker container and push it to ECR
-          docker build --build-arg NEXT_PUBLIC_TAG_ID=$GOOGLE_TAG_ID --build-arg NEXT_PUBLIC_TRACKING_ID=$TRACKING_ID -t $ECR_REPOSITORY:$IMAGE_TAG .
-          docker tag $ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-      - name: deploy
-        uses: koslib/helm-eks-action@master
-        env:
-          KUBE_CONFIG_DATA: ${{ secrets.KUBECONFIG_FILE }}
-          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
-          ECR_REPOSITORY: nhsx-standards-directory-prod
-          IMAGE_TAG: ui-${{ github.sha }}
-          PAGES_CKAN_URL: 'https://manage.standards.nhs.uk/api/'
-        with:
-          command: >-
-            helm upgrade --debug --install --wait -n prod ui ./charts/ui
-            --set ui.config.ckanurl='${{ secrets.CKAN_URL }}'
-            --set ui.config.tracking_id='${{ secrets.TRACKING_ID }}'
-            --set ui.config.google_tag_id='${{ secrets.GOOGLE_TAG_ID }}'
-            --set ui.container.image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-            --set ui.config.pagesckanurl=$PAGES_CKAN_URL
+  deploy-ui:
+    uses: nhsx/standards-registry/.github/workflows/helm-deploy-ui.yml@STAN-940/templated-builds
+    with:
+      environment: prod
+    secrets:
+      ckan_url: ${{ secrets.CKAN_URL }}
+      tracking_id: ${{ secrets.TRACKING_ID }}
+      google_tag_id: ${{ secrets.GOOGLE_TAG_ID }}
+      ecr_registry: ${{ secrets.ECR_REGISTRY }}
+      kubeconfig_file: ${{ secrets.KUBECONFIG_FILE }}
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
   ckan:
     runs-on: ubuntu-latest
     environment: prod

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ success() }}
     needs:
-      - ui
+      - deploy-ui
       - ckan
     steps:
       - name: Slack Notification

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   deploy-ui:
-    uses: nhsx/standards-registry/.github/workflows/helm-deploy-ui.yml@STAN-940/templated-builds
+    uses: nhsx/standards-registry/.github/workflows/helm-deploy-ui.yml@master
     with:
       environment: test
     secrets:

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -12,61 +12,19 @@ on:
       - success
 
 jobs:
-  ui:
-    runs-on: ubuntu-latest
-    environment: test
-    defaults:
-      run:
-        working-directory: ui
-    env:
-      AWS_REGION: eu-west-2
-    steps:
-      - name: checkout
-        uses: actions/checkout@v2
-      - name: configure credentials (doing the us-east-1 region dance 🕺)
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-      - name: Login to Public ECR
-        uses: docker/login-action@v1
-        with:
-          registry: public.ecr.aws
-          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        env:
-          AWS_REGION: ${{ env.AWS_REGION }}
-      - name: build and push
-        id: build-image
-        env:
-          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
-          ECR_REPOSITORY: nhsx-standards-directory
-          IMAGE_TAG: ui-${{ github.sha }}
-          GOOGLE_TAG_ID: ${{ secrets.GOOGLE_TAG_ID }}
-          TRACKING_ID: ${{ secrets.TRACKING_ID }}
-        run: |
-          # Build a docker container and push it to ECR
-          docker build --build-arg NEXT_PUBLIC_TAG_ID=$GOOGLE_TAG_ID --build-arg NEXT_PUBLIC_TRACKING_ID=$TRACKING_ID -t $ECR_REPOSITORY:$IMAGE_TAG .
-          docker tag $ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-      - name: UI deploy
-        uses: koslib/helm-eks-action@master
-        env:
-          AWS_REGION: eu-west-2
-          KUBE_CONFIG_DATA: ${{ secrets.KUBECONFIG_FILE }}
-          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
-          ECR_REPOSITORY: nhsx-standards-directory
-          IMAGE_TAG: ui-${{ github.sha }}
-          PAGES_CKAN_URL: 'https://manage.test.standards.nhs.uk/api/action'
-        with:
-          command: >-
-            helm upgrade --debug --install --wait -n test ui ./charts/ui
-            --set ui.config.ckanurl='${{ secrets.CKAN_URL }}'
-            --set ui.config.tracking_id='${{ secrets.TRACKING_ID }}'
-            --set ui.config.google_tag_id='${{ secrets.GOOGLE_TAG_ID }}'
-            --set ui.container.image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-            --set ui.config.pagesckanurl=$PAGES_CKAN_URL
+  deploy-ui:
+    uses: nhsx/standards-registry/.github/workflows/helm-deploy-ui.yml@STAN-940/templated-builds
+    with:
+      environment: test
+    secrets:
+      ckan_url: ${{ secrets.CKAN_URL }}
+      tracking_id: ${{ secrets.TRACKING_ID }}
+      google_tag_id: ${{ secrets.GOOGLE_TAG_ID }}
+      ecr_registry: ${{ secrets.ECR_REGISTRY }}
+      kubeconfig_file: ${{ secrets.KUBECONFIG_FILE }}
+      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
   ckan:
     runs-on: ubuntu-latest
     environment: test

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -84,7 +84,7 @@ jobs:
   integrationtest:
     if: ${{ success() }}
     needs:
-      - ui
+      - deploy-ui
       - ckan
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/helm-deploy-ui.yml
+++ b/.github/workflows/helm-deploy-ui.yml
@@ -1,11 +1,8 @@
-# TODO: workflow trigger
-# non secret inputs
-# secret inputs
 on:
   workflow_call:
     inputs:
-      app_name:
-        description: 'Which app is being deployed [ui|ckan]'
+      ckan_url:
+        description: 'The ckan url to use, e.g. https://manage.dev.standards.nhs.uk/api/action'
         required: true
         type: string
       environment:
@@ -22,10 +19,8 @@ on:
         description: 'The ECR registry to pull a docker image from'
         required: false
         type: string
-    # TODO: answer question of whether secrets can be called without specifying them as input secrets
+
     secrets:
-      ckan_url:
-        required: true
       tracking_id:
         required: true
       google_tag_id:
@@ -41,7 +36,7 @@ on:
 jobs:
   helm-upgrade:
     runs-on: ubuntu-latest
-    environment: ${{inputs.environment}}
+    environment: ${{ inputs.environment }}
     defaults:
       run:
         working-directory: ui

--- a/.github/workflows/helm-deploy-ui.yml
+++ b/.github/workflows/helm-deploy-ui.yml
@@ -1,0 +1,57 @@
+# TODO: workflow trigger
+# non secret inputs
+# secret inputs
+on:
+  workflow_call:
+    inputs:
+      app_name:
+        description: 'Which app is being deployed [ui|ckan]'
+        required: true
+        type: string
+      environment:
+        description: 'Which environment to deploy to [dev|test|prod]'
+        required: true
+        type: string
+      pages_ckan_url:
+        default: 'https://manage.standards.nhs.uk/api/action'
+        description: 'The url used to read static page information from'
+        required: false
+        type: string
+      ecr_repository:
+        default: 'nhsx-standards-directory'
+        description: 'The ECR registry to pull a docker image from'
+        required: false
+        type: string
+    # TODO: answer question of whether secrets can be called without specifying them as input secrets
+    secrets:
+      ckan_url:
+        required: true
+      tracking_id:
+        required: true
+      google_tag_id:
+        required: true
+      ecr_registry:
+        required: true
+      kubeconfig_file:
+        required: true
+
+jobs:
+  helm-upgrade:
+    runs-on: ubuntu-latest
+    environment: ${{inputs.environment}}
+
+    steps:
+      - uses: koslib/helm-eks-action@master
+        env:
+          KUBE_CONFIG_DATA: ${{ secrets.kubeconfig_file }}
+          ECR_REGISTRY: ${{ secrets.ecr_registry }}
+          ECR_REPOSITORY: ${{ inputs.ecr_repository }}
+          IMAGE_TAG: ui-${{ github.sha }}
+        with:
+          command: >-
+            helm upgrade --debug --install --wait -n {{inputs.environment}} ui ./charts/ui
+            --set ui.config.ckanurl='${{ secrets.CKAN_URL }}'
+            --set ui.config.tracking_id='${{ secrets.tracking_id }}'
+            --set ui.config.google_tag_id='${{ secrets.google_tag_id }}'
+            --set ui.container.image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+            --set ui.config.pagesckanurl=${{ inputs.pages_ckan_url }}

--- a/.github/workflows/helm-deploy-ui.yml
+++ b/.github/workflows/helm-deploy-ui.yml
@@ -1,10 +1,6 @@
 on:
   workflow_call:
     inputs:
-      ckan_url:
-        description: 'The ckan url to use, e.g. https://manage.dev.standards.nhs.uk/api/action'
-        required: true
-        type: string
       environment:
         description: 'Which environment to deploy to [dev|test|prod]'
         required: true
@@ -21,6 +17,9 @@ on:
         type: string
 
     secrets:
+      ckan_url:
+        description: 'The ckan url to use, e.g. https://manage.dev.standards.nhs.uk/api/action'
+        required: true
       tracking_id:
         required: true
       google_tag_id:
@@ -79,7 +78,7 @@ jobs:
         with:
           command: >-
             helm upgrade --debug --install --wait -n ${{inputs.environment}} ui ./charts/ui
-            --set ui.config.ckanurl='${{ inputs.ckan_url }}'
+            --set ui.config.ckanurl='${{ secrets.ckan_url }}'
             --set ui.config.tracking_id='${{ secrets.tracking_id }}'
             --set ui.config.google_tag_id='${{ secrets.google_tag_id }}'
             --set ui.container.image=${{ secrets.ecr_registry }}/${{ inputs.ecr_repository }}:$IMAGE_TAG

--- a/.github/workflows/helm-deploy-ui.yml
+++ b/.github/workflows/helm-deploy-ui.yml
@@ -18,7 +18,7 @@ on:
         required: false
         type: string
       ecr_repository:
-        default: 'nhsx-standards-directory'
+        default: nhsx-standards-directory
         description: 'The ECR registry to pull a docker image from'
         required: false
         type: string
@@ -47,16 +47,19 @@ jobs:
         working-directory: ui
     env:
       AWS_REGION: eu-west-2
+      IMAGE_TAG: ui-${{ github.sha }}
 
     steps:
       - name: checkout
         uses: actions/checkout@v2
+
       - name: configure credentials (using us-east-1)
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.aws_access_key_id }}
           aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
           aws-region: us-east-1
+
       - name: Login to Public ECR
         uses: docker/login-action@v1
         with:
@@ -65,17 +68,24 @@ jobs:
           password: ${{ secrets.aws_secret_access_key }}
         env:
           AWS_REGION: ${{ env.AWS_REGION }}
-      - uses: koslib/helm-eks-action@master
+
+      - name: build and push
+        id: build-image
+        run: |
+          # Build a docker container and push it to ECR
+          docker build --build-arg NEXT_PUBLIC_TAG_ID=${{ secrets.google_tag_id }} --build-arg NEXT_PUBLIC_TRACKING_ID=${{ secrets.tracking_id }} -t ${{ inputs.ecr_repository }}:$IMAGE_TAG .
+          docker tag ${{ inputs.ecr_repository }}:$IMAGE_TAG ${{ secrets.ecr_registry }}/${{ inputs.ecr_repository }}:$IMAGE_TAG
+          docker push ${{ secrets.ecr_registry }}/${{ inputs.ecr_repository }}:$IMAGE_TAG
+
+      - name: update helm
+        uses: koslib/helm-eks-action@master
         env:
           KUBE_CONFIG_DATA: ${{ secrets.kubeconfig_file }}
-          ECR_REGISTRY: ${{ secrets.ecr_registry }}
-          ECR_REPOSITORY: ${{ inputs.ecr_repository }}
-          IMAGE_TAG: ui-${{ github.sha }}
         with:
           command: >-
             helm upgrade --debug --install --wait -n ${{inputs.environment}} ui ./charts/ui
-            --set ui.config.ckanurl='${{ secrets.CKAN_URL }}'
+            --set ui.config.ckanurl='${{ secrets.ckan_url }}'
             --set ui.config.tracking_id='${{ secrets.tracking_id }}'
             --set ui.config.google_tag_id='${{ secrets.google_tag_id }}'
-            --set ui.container.image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+            --set ui.container.image=${{ secrets.ecr_registry }}/${{ inputs.ecr_repository }}:$IMAGE_TAG
             --set ui.config.pagesckanurl=${{ inputs.pages_ckan_url }}

--- a/.github/workflows/helm-deploy-ui.yml
+++ b/.github/workflows/helm-deploy-ui.yml
@@ -34,13 +34,37 @@ on:
         required: true
       kubeconfig_file:
         required: true
-
+      aws_access_key_id:
+        required: true
+      aws_secret_access_key:
+        required: true
 jobs:
   helm-upgrade:
     runs-on: ubuntu-latest
     environment: ${{inputs.environment}}
+    defaults:
+      run:
+        working-directory: ui
+    env:
+      AWS_REGION: eu-west-2
 
     steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: configure credentials (using us-east-1)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.aws_access_key_id }}
+          aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
+          aws-region: us-east-1
+      - name: Login to Public ECR
+        uses: docker/login-action@v1
+        with:
+          registry: public.ecr.aws
+          username: ${{ secrets.aws_access_key_id }}
+          password: ${{ secrets.aws_secret_access_key }}
+        env:
+          AWS_REGION: ${{ env.AWS_REGION }}
       - uses: koslib/helm-eks-action@master
         env:
           KUBE_CONFIG_DATA: ${{ secrets.kubeconfig_file }}
@@ -49,7 +73,7 @@ jobs:
           IMAGE_TAG: ui-${{ github.sha }}
         with:
           command: >-
-            helm upgrade --debug --install --wait -n {{inputs.environment}} ui ./charts/ui
+            helm upgrade --debug --install --wait -n ${{inputs.environment}} ui ./charts/ui
             --set ui.config.ckanurl='${{ secrets.CKAN_URL }}'
             --set ui.config.tracking_id='${{ secrets.tracking_id }}'
             --set ui.config.google_tag_id='${{ secrets.google_tag_id }}'

--- a/.github/workflows/helm-deploy-ui.yml
+++ b/.github/workflows/helm-deploy-ui.yml
@@ -16,7 +16,7 @@ on:
         type: string
       ecr_repository:
         default: nhsx-standards-directory
-        description: 'The ECR registry to pull a docker image from'
+        description: 'The ECR registry to use for the built image'
         required: false
         type: string
 
@@ -34,7 +34,7 @@ on:
       aws_secret_access_key:
         required: true
 jobs:
-  helm-upgrade:
+  container-and-helm:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     defaults:
@@ -79,7 +79,7 @@ jobs:
         with:
           command: >-
             helm upgrade --debug --install --wait -n ${{inputs.environment}} ui ./charts/ui
-            --set ui.config.ckanurl='${{ secrets.ckan_url }}'
+            --set ui.config.ckanurl='${{ inputs.ckan_url }}'
             --set ui.config.tracking_id='${{ secrets.tracking_id }}'
             --set ui.config.google_tag_id='${{ secrets.google_tag_id }}'
             --set ui.container.image=${{ secrets.ecr_registry }}/${{ inputs.ecr_repository }}:$IMAGE_TAG


### PR DESCRIPTION
* Pulls out the yaml from each workflow and sections off to a reusable one for deploying the UI
* also resets our workflow operations to go sequentially through test => dev => test => prod
  * we're still building and pulling a docker image in each job, in a subsequent PR I'll look into minimising the docker operations

<img width="1345" alt="Capture d’écran 2022-09-02 à 11 26 42" src="https://user-images.githubusercontent.com/120181/188110467-73435910-5e94-4484-af06-624ec91a8dae.png">
