### PR TITLE
[STAN-938] Add independent integration test workflow, point pages url at prod

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,31 +28,8 @@ jobs:
       - run: npm test
 
   integrationtest:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ui
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Cypress run
-        uses: cypress-io/github-action@v4
-        with:
-          working-directory: ui
-          build: npm run build --if-present
-          start: npm start
-        env:
-          CKAN_URL: https://manage.test.standards.nhs.uk/api/action
-          PAGES_CKAN_URL: https://manage.test.standards.nhs.uk/api/action
-          PORT: 3000
-      - uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: cypress-screenshots
-          path: ui/cypress/screenshots
-      # Test run video was always captured, so this action uses "always()" condition
-      - uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: cypress-videos
-          path: ui/cypress/videos
+    uses: nhsx/standards-registry/.github/workflows/integration-test.yml@master
+    with:
+      base_url: localhost
+      ckan_url: https://manage.test.standards.nhs.uk/api/action
+      pages_ckan_url: https://manage.standards.nhs.uk/api/action

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,16 +1,15 @@
 name: deploy-dev
 
 on:
-  - push
-  # workflow_run:
-  #   branches:
-  #     - master
-  #   workflows:
-  #     - build-and-test
-  #   types:
-  #     - completed
-  #   conclusion:
-  #     - success
+  workflow_run:
+    branches:
+      - master
+    workflows:
+      - build-and-test
+    types:
+      - completed
+    conclusion:
+      - success
 
 jobs:
   deploy-csv-exporter:
@@ -109,7 +108,7 @@ jobs:
       - deploy-csv-exporter
       - deploy-ui
       - ckan
-    uses: nhsx/standards-registry/.github/workflows/integration-test.yml@STAN-938/point-pages-at-prod
+    uses: nhsx/standards-registry/.github/workflows/integration-test.yml@master
     with:
       base_url: https://dev.standards.nhs.uk
       ckan_url: https://manage.dev.standards.nhs.uk/api/action

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,15 +1,16 @@
 name: deploy-dev
 
 on:
-  workflow_run:
-    branches:
-      - master
-    workflows:
-      - build-and-test
-    types:
-      - completed
-    conclusion:
-      - success
+  - push
+  # workflow_run:
+  #   branches:
+  #     - master
+  #   workflows:
+  #     - build-and-test
+  #   types:
+  #     - completed
+  #   conclusion:
+  #     - success
 
 jobs:
   deploy-csv-exporter:
@@ -105,38 +106,14 @@ jobs:
   integrationtest:
     if: ${{ success() }}
     needs:
+      - deploy-csv-exporter
       - deploy-ui
       - ckan
-      - deploy-csv-exporter
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ui
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Cypress run
-        uses: cypress-io/github-action@v4
-        with:
-          working-directory: ui
-          build: npm run build --if-present
-          start: npm start
-        env:
-          BASE_URL: https://dev.standards.nhs.uk
-          CKAN_URL: https://manage.dev.standards.nhs.uk/api/action
-          PAGES_CKAN_URL: https://manage.test.standards.nhs.uk/api/action
-          PORT: 3000
-      - uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: cypress-screenshots
-          path: ui/cypress/screenshots
-      # Test run video was always captured, so this action uses "always()" condition
-      - uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: cypress-videos
-          path: ui/cypress/videos
+    uses: nhsx/standards-registry/.github/workflows/integration-test.yml@STAN-938/point-pages-at-prod
+    with:
+      base_url: https://dev.standards.nhs.uk
+      ckan_url: https://manage.dev.standards.nhs.uk/api/action
+      pages_ckan_url: https://manage.standards.nhs.uk/api/action
 
   notifypass:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -89,7 +89,7 @@ jobs:
     needs:
       - deploy-ui
       - ckan
-    uses: nhsx/standards-registry/.github/workflows/integration-test.yml@STAN-938/point-pages-at-prod
+    uses: nhsx/standards-registry/.github/workflows/integration-test.yml@master
     with:
       base_url: https://data.standards.nhs.uk
       ckan_url: https://manage.standards.nhs.uk/api/action

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -84,6 +84,17 @@ jobs:
             --set ckan.psql.initialize=false
             --set solr.initialize.enabled=false
 
+  integrationtest:
+    if: ${{ success() }}
+    needs:
+      - deploy-ui
+      - ckan
+    uses: nhsx/standards-registry/.github/workflows/integration-test.yml@STAN-938/point-pages-at-prod
+    with:
+      base_url: https://data.standards.nhs.uk
+      ckan_url: https://manage.standards.nhs.uk/api/action
+      pages_ckan_url: https://manage.standards.nhs.uk/api/action
+
   notifypass:
     runs-on: ubuntu-latest
     if: ${{ success() }}

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -86,35 +86,11 @@ jobs:
     needs:
       - deploy-ui
       - ckan
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ui
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Cypress run
-        uses: cypress-io/github-action@v4
-        with:
-          working-directory: ui
-          build: npm run build --if-present
-          start: npm start
-        env:
-          BASE_URL: https://test.standards.nhs.uk
-          CKAN_URL: https://manage.test.standards.nhs.uk/api/action
-          PAGES_CKAN_URL: https://manage.test.standards.nhs.uk/api/action
-          PORT: 3000
-      - uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: cypress-screenshots
-          path: ui/cypress/screenshots
-      # Test run video was always captured, so this action uses "always()" condition
-      - uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: cypress-videos
-          path: ui/cypress/videos
+    uses: nhsx/standards-registry/.github/workflows/integration-test.yml@STAN-938/point-pages-at-prod
+    with:
+      base_url: https://test.standards.nhs.uk
+      ckan_url: https://manage.test.standards.nhs.uk/api/action
+      pages_ckan_url: https://manage.standards.nhs.uk/api/action
 
   notifypass:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -86,7 +86,7 @@ jobs:
     needs:
       - deploy-ui
       - ckan
-    uses: nhsx/standards-registry/.github/workflows/integration-test.yml@STAN-938/point-pages-at-prod
+    uses: nhsx/standards-registry/.github/workflows/integration-test.yml@master
     with:
       base_url: https://test.standards.nhs.uk
       ckan_url: https://manage.test.standards.nhs.uk/api/action

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,48 @@
+on:
+  workflow_call:
+    inputs:
+      base_url:
+        description: 'The ui url, e.g. https://dev.standards.nhs.uk'
+        required: true
+        type: string
+      ckan_url:
+        description: 'The CKAN API endpoint for the frontend to call, e.g. https://manage.dev.standards.nhs.uk/api/action'
+        required: true
+        type: string
+      pages_ckan_url:
+        description: 'The url we use to get static content, usually prod, e.g.  https://manage.standards.nhs.uk/api/action'
+        required: true
+        type: string
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ui
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cypress run
+        uses: cypress-io/github-action@v4
+        with:
+          working-directory: ui
+          build: npm run build --if-present --omit-dev
+          start: npm start
+        env:
+          BASE_URL: ${{ inputs.base_url }}
+          CKAN_URL: ${{ inputs.ckan_url }}
+          PAGES_CKAN_URL: ${{ inputs.pages_ckan_url }}
+          PORT: 3000
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: ui/cypress/screenshots
+      # Test run video was always captured, so this action uses "always()" condition
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: cypress-videos
+          path: ui/cypress/videos


### PR DESCRIPTION
* We call integration test in 4 places, (deploy dev, test, prod, build-and-test)
* Move it to a single configurable file
* call it! 
* Set the `pages_ckan_url` appropriately per env (hint: they're all pointing at prod now)