### PR TITLE
Bugfix - filters

### DIFF
--- a/ui/components/Dataset/index.js
+++ b/ui/components/Dataset/index.js
@@ -1,6 +1,5 @@
 import Link from 'next/link';
-import isEqual from 'lodash/isEqual';
-import { useState, useMemo } from 'react';
+import { useState, useEffect } from 'react';
 import { Tag, Flex, Pagination, FilterSummary, Select } from '../';
 import upperFirst from 'lodash/upperFirst';
 import format from 'date-fns/format';
@@ -175,14 +174,14 @@ export default function Dataset({
   schema,
 }) {
   const { query } = useQueryContext();
-  const [currentQuery, setCurrentQuery] = useState(query);
   const searchTerm = query.q;
   const [data, setData] = useState(initialData);
   const [loading, setLoading] = useState(false);
   const { count = 0, results = [] } = data;
+  const [pageLoaded, setPageLoaded] = useState(false);
   const filtersSelected = Object.keys(query).length > 0;
 
-  useMemo(() => {
+  useEffect(() => {
     async function getData() {
       try {
         setLoading(true);
@@ -194,12 +193,13 @@ export default function Dataset({
         setLoading(false);
       }
     }
-
-    if (!isEqual(query, currentQuery)) {
+    // we dont want to fetch data on initial load.
+    if (pageLoaded) {
       getData();
-      setCurrentQuery(query);
     }
   }, [query]);
+
+  useEffect(() => setPageLoaded(true), []);
 
   return (
     <>

--- a/ui/context/query.js
+++ b/ui/context/query.js
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router';
 import { createContext, useContext } from 'react';
-import { pickBy } from 'lodash';
+import { pickBy, size, omit } from 'lodash';
 
 const QueryContext = createContext();
 
@@ -22,6 +22,17 @@ export function QueryContextWrapper({ children }) {
 
   function updateQuery(props, { replace, overwrite } = {}) {
     const { query } = router;
+
+    if (query.page && size(omit(props, 'page'))) {
+      delete query.page;
+    }
+
+    if (query.page && props.page) {
+      if (parseInt(query.page) === parseInt(props.page)) {
+        delete query.page;
+        delete props.page;
+      }
+    }
 
     const newQuery = overwrite
       ? props

--- a/ui/cypress/e2e/standards/list.cy.js
+++ b/ui/cypress/e2e/standards/list.cy.js
@@ -12,6 +12,55 @@ describe('Standards Listing Index', () => {
     cy.get('#browse-results li').should('have.length', 10);
   });
 
+  describe.only('filters and pagination', () => {
+    it('Can change page', () => {
+      cy.visit('/current-standards');
+      cy.get('.nhsuk-pagination').contains('a', 'Next').click();
+      cy.url().should('contain', 'page=2');
+
+      cy.get('.nhsuk-pagination').contains('a', 'Next').click();
+      cy.url().should('contain', 'page=3');
+
+      cy.get('.nhsuk-pagination').contains('a', 'Prev').click();
+      cy.url().should('contain', 'page=2');
+
+      cy.get('.nhsuk-pagination').contains('a', 'Prev').click();
+      cy.url().should('contain', 'page=1');
+    });
+
+    it('Can filter by mandated, and remove filter (regression)', () => {
+      cy.visit('/current-standards');
+      let results;
+      cy.get('span[role="status"]').should((el) => {
+        results = parseInt(el.text().replace(' Results', ''));
+      });
+      cy.get('#mandated').click();
+
+      cy.get('span[role="status"]').should((el) => {
+        const filteredResults = parseInt(el.text().replace(' Results', ''));
+        expect(filteredResults).to.be.lessThan(results);
+      });
+
+      cy.get('#mandated').click();
+
+      cy.get('span[role="status"]').should((el) => {
+        const filteredResults = parseInt(el.text().replace(' Results', ''));
+        expect(filteredResults).to.be.equal(results);
+      });
+    });
+
+    it('Resets page when filtered', () => {
+      cy.visit('/current-standards');
+      cy.get('.nhsuk-pagination').contains('a', 'Next').click();
+      cy.url().should('contain', 'page=2');
+
+      cy.get('#mandated').click();
+
+      cy.url().should('not.contain', 'page');
+      cy.url().should('contain', 'mandated');
+    });
+  });
+
   describe('Search', () => {
     it('Can search by standard matching', () => {
       cy.visit('/current-standards');


### PR DESCRIPTION
* Updated dataset logic to use a pageLoaded flag in place of the query comparison. This was failing to pick up when filters were removed
* Updated query builder to reset page when something other than page is changed