### PR TITLE
Bugfix - search disappears on mobile

### DIFF
--- a/ui/components/Search/style.module.scss
+++ b/ui/components/Search/style.module.scss
@@ -2,6 +2,15 @@
   &.full-width {
     float: none;
     width: 100%;
+
+    :global {
+      .nhsuk-header__search-wrap {
+        display: block;
+      }
+      .nhsuk-search__close {
+        display: none;
+      }
+    }
   }
 
   :global {


### PR DESCRIPTION
* Added custom override to stop search disappearing on mobile. This is only desired behaviour when search is in the header element