### PR TITLE
Add "local" as an option for dataset imports

### DIFF
--- a/reader/lib/write/index.js
+++ b/reader/lib/write/index.js
@@ -32,7 +32,8 @@ export const isPublished = (status) =>
 const writeRecord = async ({ record, headers, ckanUrl, dryRun } = {}) => {
   await sleep(150); //sleep .15s between hits to the api
 
-  const { title, reference_code, status, is_published_standard } = record;
+  const { title, reference_code, status, is_published_standard, organization } =
+    record;
   // Slugify titles in a similar fashion to CKAN auto-slug
   const name = slugify(title, { lower: true, strict: true });
   console.log('\n * Processing record:\n  ', title);
@@ -42,6 +43,7 @@ const writeRecord = async ({ record, headers, ckanUrl, dryRun } = {}) => {
       name,
       mandated: !!reference_code,
       is_published_standard: is_published_standard || isPublished(status),
+      owner_org: organization.name,
     },
   };
   let recordToWrite = params;
@@ -49,6 +51,7 @@ const writeRecord = async ({ record, headers, ckanUrl, dryRun } = {}) => {
   if (dryRun) {
     console.log('DRY RUN:');
     console.log('DRY RUN: RECORD ENTRY', record);
+    console.log('DRY RUN HEADERS', headers);
     return;
   }
 
@@ -84,6 +87,8 @@ const writeRecord = async ({ record, headers, ckanUrl, dryRun } = {}) => {
     });
 
     const writeData = await write.json();
+
+    console.log('the writeData was>', writeData);
     const { success } = writeData;
 
     const statusStr = success ? 'successful' : 'unsuccessful';

--- a/reader/write-json-to-ckan.js
+++ b/reader/write-json-to-ckan.js
@@ -34,9 +34,9 @@ program
   )
   .addOption(
     new Option(
-      '-w, --write-location <dev|test|prod>',
+      '-w, --write-location <local|dev|test|prod>',
       'environment to write to'
-    ).choices(['dev', 'test', 'prod'])
+    ).choices(['local', 'dev', 'test', 'prod'])
   )
   .option('--dry-run <bool>', 'set dry-run', false);
 
@@ -52,10 +52,12 @@ ${location}`);
 
 // map dev,test,prod to nhs domains
 const mapEnv = (to) =>
-  `https://manage.${to.replace(
-    'prod',
-    ''
-  )}.standards.nhs.uk/api/action`.replace('..', '.');
+  to === 'local'
+    ? 'http://localhost:5005/api/action'
+    : `https://manage.${to.replace(
+        'prod',
+        ''
+      )}.standards.nhs.uk/api/action`.replace('..', '.');
 
 const res = await fetch(location);
 const data = await res.json();


### PR DESCRIPTION
Having nuked my local CKAN setup this was very useful for importing all records from production to local

* extends write-location option: `'-w, --write-location <local|dev|test|prod>',`
* updates `owner_org` to use the org name, as the id was different and wouldn't allow for a successful write
* Makes the output a bit louder just in case you don't want to check the final log