### PR TITLE
Add automated lighthouse tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -46,3 +46,8 @@ jobs:
         with:
           name: cypress-videos
           path: ui/cypress/videos
+
+      - name: Site quality test
+        uses: nhsx/standards-registry/.github/workflows/lighthouse-test.yml@master
+        with:
+          test_url: ${{ inputs.base_url }}

--- a/.github/workflows/lighthouse-test.yml
+++ b/.github/workflows/lighthouse-test.yml
@@ -1,0 +1,28 @@
+name: Lighthouse
+on:
+  workflow_call:
+    inputs:
+      test_url:
+        description: 'The url to test on workflow call, e.g. "https://dev.standards.nhs.uk"'
+        required: true
+        type: string
+        default: 'https://data.standards.nhs.uk'
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lighthouse
+      - uses: actions/checkout@master
+      - run: mkdir -p ${{ github.workspace }}/tmp/artifacts
+        uses: foo-software/lighthouse-check-action@master
+        with:
+          outputDirectory: ${{ github.workspace }}/tmp/artifacts
+          urls: ${{ inputs.test_url }}
+          slackWebhookUrl: ${{ secrets.SLACK_WEBHOOK }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@master
+        with:
+          name: Lighthouse reports
+          path: ${{ github.workspace }}/tmp/artifacts


### PR DESCRIPTION
* see https://github.com/foo-software/lighthouse-check-action
* adds an automated check of page quality using google lighthouse / https://web.dev/measure/
* only checks the homepage but can be run against multiple locations in the future
* can be modified to include minimum scores which we can fail on
* should notify us in slack on failure

**Artefacts uploaded on run:**

![image](https://lighthouse-check.s3.amazonaws.com/images/github-actions/github-action-lighthouse-check-artifacts.png)

**Slack notifications:**

![image](https://user-images.githubusercontent.com/120181/190624617-15a64156-30d9-40a4-9893-14de62f8adb6.png)
