### PR TITLE
[STAN-1059] meta descriptions from ckan

### DIFF
--- a/ui/components/Layout/index.js
+++ b/ui/components/Layout/index.js
@@ -29,7 +29,10 @@ export default function Home({ children, ...props }) {
     'about-standards',
     'help-and-resources',
   ].map((name) => {
-    const page = pages.find((p) => p.name === name);
+    const page = pages.find((p) => p.name === name) || {
+      name,
+      short_title: 'missing',
+    };
     return {
       url: `/${page.name}`,
       label: page.short_title,

--- a/ui/pages/[page].js
+++ b/ui/pages/[page].js
@@ -20,9 +20,9 @@ const descriptions = {
     'Check who owns and manages the NHS Data Standards Directory and what the service is for.',
 };
 
-const StaticPage = ({ content, showToc, title, parsed, page }) => {
+const StaticPage = ({ content, showToc, title, parsed, description, page }) => {
   return (
-    <Page title={title} description={descriptions[page]}>
+    <Page title={title} description={description || descriptions[page]}>
       <div className="nhsuk-grid-row">
         {showToc && <TableOfContents content={parsed} />}
         <div className="nhsuk-grid-column-two-thirds">
@@ -49,6 +49,7 @@ export async function getServerSideProps(context) {
     title,
     content: unsanitised,
     show_table_of_contents: showToc,
+    meta_description: description,
   } = pageData;
 
   const content = DOMPurify.sanitize(parse(unsanitised));
@@ -58,6 +59,7 @@ export async function getServerSideProps(context) {
     props: {
       pages,
       showToc,
+      description,
       content,
       title,
       parsed,


### PR DESCRIPTION
### CKAN Pages

<img width="826" alt="Capture d’écran 2022-10-05 à 13 23 46" src="https://user-images.githubusercontent.com/120181/194049933-cc321d81-dfc0-45d1-bed2-cdb2f9423be0.png">

### UI

<img width="1072" alt="Capture d’écran 2022-10-05 à 13 24 00" src="https://user-images.githubusercontent.com/120181/194049917-fb4232d5-83ea-4a60-abb4-02e2d5c89f86.png">
