### PR TITLE
[STAN-1075] Update tag colour mappings

### DIFF
--- a/ui/components/Dataset/index.js
+++ b/ui/components/Dataset/index.js
@@ -1,7 +1,6 @@
 import Link from 'next/link';
 import { useState, useEffect } from 'react';
 import { Tag, Flex, Pagination, FilterSummary, Select } from '../';
-import upperFirst from 'lodash/upperFirst';
 import format from 'date-fns/format';
 import parseISO from 'date-fns/parseISO';
 import classnames from 'classnames';
@@ -56,7 +55,7 @@ function Model({ model }) {
         <p className={classnames('nhsuk-body-s', styles.noBottom)}>
           Status:{' '}
           <Tag type={status} classes="nhsuk-body-s">
-            {upperFirst(status)}
+            {status}
           </Tag>
         </p>
         <p

--- a/ui/components/Tag/index.js
+++ b/ui/components/Tag/index.js
@@ -1,13 +1,20 @@
 import classnames from 'classnames';
+import { upperFirst } from 'lodash';
+
+const formatTagValue = (value) => upperFirst(value.replace(/-/g, ' '));
 
 const colorMap = {
+  proposed: 'nhsuk-tag--white',
+  draft: 'nhsuk-tag--grey',
+  'awaiting-approval': 'nhsuk-tag--aqua-green',
+  cancelled: 'nhsuk-tag--pink',
+  'draft-in-progress': 'nhsuk-tag--grey',
+  'on-hold': 'nhsuk-tag--yellow',
+
   active: 'nhsuk-tag--green',
+  'in-development': 'nhsuk-tag--grey',
   deprecated: 'nhsuk-tag--orange',
   retired: 'nhsuk-tag--red',
-  draft: 'nhsuk-tag--grey',
-  // proposed: 'nhsuk-tag--grey',
-  // awaiting: 'nhsuk-tag--grey',
-  // discontinued: 'nhsuk-tag--grey',
 };
 
 export default function TypeTag({ children, classes, type }) {
@@ -20,7 +27,7 @@ export default function TypeTag({ children, classes, type }) {
           null
       )}
     >
-      {children}
+      {formatTagValue(children)}
     </span>
   );
 }

--- a/ui/schema/index.js
+++ b/ui/schema/index.js
@@ -45,7 +45,7 @@ const schema = [
       label: 'Status',
       format: (val) => (
         <>
-          <Tag type={val}>{upperFirst(val)}</Tag>
+          <Tag type={val}>{val}</Tag>
           {
             <Details
               className="nhsuk-u-font-size-16 nhsuk-u-margin-top-4"


### PR DESCRIPTION
- Updates our colour mappings for new status types
- draft is still mapped just in case we have some stragglers
- Redid the status formatting to sentence case values

<img width="463" alt="Capture d’écran 2022-10-06 à 17 38 03" src="https://user-images.githubusercontent.com/120181/194357857-d54d3ef8-1dc3-4f05-8ed0-c732c4bf63f0.png">
<img width="718" alt="Capture d’écran 2022-10-06 à 17 36 15" src="https://user-images.githubusercontent.com/120181/194357863-51a9c154-2715-42c3-8b39-a4a476bd2eba.png">

NB: we'll need to update `What this status means` too

<img width="449" alt="Capture d’écran 2022-10-06 à 17 42 44" src="https://user-images.githubusercontent.com/120181/194358018-519f4af1-c694-4009-815d-b019c619bdb0.png">
