### PR TITLE
[STAN-997] Add meta descriptions to standards id pages

### DIFF
--- a/ui/pages/current-standards/[id].js
+++ b/ui/pages/current-standards/[id].js
@@ -4,12 +4,13 @@ import { read, getPages } from '../../helpers/api';
 import schema from '../../schema';
 
 const Id = ({ data }) => {
+  const { title, description } = data;
   return (
-    <Page title={data.title}>
+    <Page title={title} description={description}>
       <Reading>
-        <h1>{data.title}</h1>
+        <h1>{title}</h1>
         <div className="nhsuk-u-reading-width">
-          <p>{data.description}</p>
+          <p>{description}</p>
         </div>
       </Reading>
       <Row>


### PR DESCRIPTION
A simple change that passes through a standard's description to the Page component, rendering descriptions into a meta tag when available:

<img width="1072" alt="Capture d’écran 2022-10-07 à 12 25 18" src="https://user-images.githubusercontent.com/120181/194533803-61e6aab0-d15f-4910-9e57-ef0dfe4be802.png">
