### PR TITLE
[STAN-981] Add schema.org annotations to standards

### DIFF
--- a/ui/components/DatasetSchema/index.js
+++ b/ui/components/DatasetSchema/index.js
@@ -6,7 +6,6 @@ export function DatasetSchema({
   title,
   description,
   documentation_link: url,
-  license,
   keywords,
   metadata_created: dateCreated,
   metadata_modified: dateModified,
@@ -22,7 +21,6 @@ export function DatasetSchema({
     dateModified,
     identifier,
     url,
-    license,
     author: organization.name,
     keywords,
   };

--- a/ui/components/DatasetSchema/index.js
+++ b/ui/components/DatasetSchema/index.js
@@ -1,0 +1,37 @@
+import Head from 'next/head';
+
+// See https://schema.org/Dataset for more
+
+export function DatasetSchema({
+  title,
+  description,
+  documentation_link: url,
+  license,
+  keywords,
+  metadata_created: dateCreated,
+  metadata_modified: dateModified,
+  organization,
+  reference_code: identifier,
+}) {
+  const datasetJSON = {
+    '@context': 'https://schema.org/',
+    '@type': 'Dataset',
+    name: title,
+    description,
+    dateCreated,
+    dateModified,
+    identifier,
+    url,
+    license,
+    author: organization.name,
+    keywords,
+  };
+
+  return (
+    <Head>
+      <script className="structured-data-list" type="application/ld+json">
+        {JSON.stringify(datasetJSON)}
+      </script>
+    </Head>
+  );
+}

--- a/ui/components/index.js
+++ b/ui/components/index.js
@@ -25,6 +25,7 @@ export { default as PhaseBanner } from './PhaseBanner';
 export { default as Reading } from './Reading';
 export * from './ResponsiveTable';
 export { default as Snippet } from './Snippet';
+export { DatasetSchema } from './DatasetSchema';
 export { default as Search } from './Search';
 export * from './Select';
 export { default as Tag } from './Tag';

--- a/ui/pages/current-standards/[id].js
+++ b/ui/pages/current-standards/[id].js
@@ -1,4 +1,12 @@
-import { Page, Reading, Row, Col, Model, ReviewDates } from '../../components';
+import {
+  Page,
+  Reading,
+  Row,
+  Col,
+  Model,
+  ReviewDates,
+  DatasetSchema,
+} from '../../components';
 
 import { read, getPages } from '../../helpers/api';
 import schema from '../../schema';
@@ -6,20 +14,23 @@ import schema from '../../schema';
 const Id = ({ data }) => {
   const { title, description } = data;
   return (
-    <Page title={title} description={description}>
-      <Reading>
-        <h1>{title}</h1>
-        <div className="nhsuk-u-reading-width">
-          <p>{description}</p>
-        </div>
-      </Reading>
-      <Row>
-        <Col className="nhsuk-grid-column-two-thirds">
-          <Model schema={schema} data={data} />
-          <ReviewDates data={data} />
-        </Col>
-      </Row>
-    </Page>
+    <>
+      <DatasetSchema {...data} />
+      <Page title={title} description={description}>
+        <Reading>
+          <h1>{title}</h1>
+          <div className="nhsuk-u-reading-width">
+            <p>{description}</p>
+          </div>
+        </Reading>
+        <Row>
+          <Col className="nhsuk-grid-column-two-thirds">
+            <Model schema={schema} data={data} />
+            <ReviewDates data={data} />
+          </Col>
+        </Row>
+      </Page>
+    </>
   );
 };
 


### PR DESCRIPTION
See https://schema.org/Dataset for more

* produces a json/ld representation of a standard in the `<head>` of the document

### Example
For this page, https://data.standards.nhs.uk/current-standards/national-cancer-waiting-times-monitoring-data-set
#### Scema.org output:
<img width="904" alt="Capture d’écran 2022-10-12 à 17 46 49" src="https://user-images.githubusercontent.com/120181/195389354-8b39a3cc-95a7-48ea-8297-d0374c3bface.png">
Tested using https://validator.schema.org/

#### [JSON-LD](https://json-ld.org/) output

<img width="731" alt="Capture d’écran 2022-10-12 à 17 47 09" src="https://user-images.githubusercontent.com/120181/195389474-82142576-3c9c-4487-b620-60c8aa23b470.png">

#### The page

<img width="834" alt="Capture d’écran 2022-10-12 à 17 46 56" src="https://user-images.githubusercontent.com/120181/195389611-45fd542e-1356-43d0-88a4-759510fc973f.png">

