### PR TITLE
[STAN-978] Add WebPage schema to all pages

### DIFF
--- a/ui/components/DatasetSchema/index.js
+++ b/ui/components/DatasetSchema/index.js
@@ -64,8 +64,10 @@ export function WebPageSchema({ title, description, host }) {
     title,
     description,
     url: [host, router.asPath].join(''),
-    // Contact point for page: email
-    // creator nhs digitial org
+    contactPoint: {
+      '@type': 'ContactPoint',
+      email: 'england.interop.standards@nhs.net',
+    },
   };
   return addJsonToHead(data);
 }

--- a/ui/components/DatasetSchema/index.js
+++ b/ui/components/DatasetSchema/index.js
@@ -1,4 +1,13 @@
 import Head from 'next/head';
+import { useRouter } from 'next/router';
+
+const addJsonToHead = (schemaJSON) => (
+  <Head>
+    <script className="structured-data-list" type="application/ld+json">
+      {JSON.stringify(schemaJSON)}
+    </script>
+  </Head>
+);
 
 // See https://schema.org/Dataset for more
 
@@ -40,11 +49,23 @@ export function DatasetSchema({
     },
   };
 
-  return (
-    <Head>
-      <script className="structured-data-list" type="application/ld+json">
-        {JSON.stringify(datasetJSON)}
-      </script>
-    </Head>
-  );
+  return addJsonToHead(datasetJSON);
+}
+
+// Schema:title - Title
+// Schema:description - Description
+// Schema:url - defined url of page
+
+export function WebPageSchema({ title, description, host }) {
+  const router = useRouter();
+  const data = {
+    '@context': 'https://schema.org/',
+    '@type': 'WebPage',
+    title,
+    description,
+    url: [host, router.asPath].join(''),
+    // Contact point for page: email
+    // creator nhs digitial org
+  };
+  return addJsonToHead(data);
 }

--- a/ui/components/Page/index.js
+++ b/ui/components/Page/index.js
@@ -1,16 +1,16 @@
 import Head from 'next/head';
 import { useContentContext } from '../../context/content';
+import { WebPageSchema } from '../DatasetSchema';
 
-export default function Page({ children, ...props }) {
+export default function Page({ children, host, description, title }) {
   const { setPageTitle } = useContentContext();
-  const title = setPageTitle(props.title);
+  const pageTitle = setPageTitle(title);
   return (
     <>
+      <WebPageSchema title={title} description={description} host={host} />
       <Head>
-        <title>{title}</title>
-        {props.description && (
-          <meta name="description" value={props.description} />
-        )}
+        <title>{pageTitle}</title>
+        {description && <meta name="description" value={description} />}
       </Head>
       {children}
     </>

--- a/ui/components/index.js
+++ b/ui/components/index.js
@@ -25,7 +25,7 @@ export { default as PhaseBanner } from './PhaseBanner';
 export { default as Reading } from './Reading';
 export * from './ResponsiveTable';
 export { default as Snippet } from './Snippet';
-export { DatasetSchema } from './DatasetSchema';
+export { DatasetSchema, WebPageSchema } from './DatasetSchema';
 export { default as Search } from './Search';
 export * from './Select';
 export { default as Tag } from './Tag';

--- a/ui/context/content.js
+++ b/ui/context/content.js
@@ -12,13 +12,15 @@ const ContentContext = createContext();
 
 export function ContentContextWrapper({ children, value }) {
   const content = merge({}, CONTENT, value);
-
   const delimiter = ' - ';
+  const contentMerge = (content) => {
+    return { ...CONTENT, ...content };
+  };
 
   const setPageTitle = (pageTitle) =>
     pageTitle ? [pageTitle, content.title].join(delimiter) : content.title;
 
-  const functions = { content, setPageTitle };
+  const functions = { content, setPageTitle, contentMerge };
   return (
     <ContentContext.Provider value={functions}>
       {children}

--- a/ui/cypress/e2e/schema.org.cy.js
+++ b/ui/cypress/e2e/schema.org.cy.js
@@ -1,6 +1,10 @@
 const parseJsonSchema = (elem) =>
   JSON.parse(
-    JSON.stringify(elem.text()).replaceAll('&quot;', '"').trim().slice(1, -1)
+    JSON.stringify(elem.text())
+      .replaceAll('&quot;', '"')
+      .replaceAll('\\', '')
+      .trim()
+      .slice(1, -1)
   );
 
 describe('Schema.org representations', () => {
@@ -11,9 +15,14 @@ describe('Schema.org representations', () => {
         .get('head script[class="structured-data-list"]')
         .then((jsonSchema) => {
           expect(jsonSchema).to.have.attr('type', 'application/ld+json');
+
           expect(parseJsonSchema(jsonSchema)).to.deep.equal({
             '@context': 'https://schema.org/',
             '@type': 'WebPage',
+            contactPoint: {
+              '@type': 'ContactPoint',
+              email: 'england.interop.standards@nhs.net',
+            },
             title: 'Help and resources',
             description:
               'Explore resources for the data standards community in health and social care including links to discussion forums and government regulations.',

--- a/ui/cypress/e2e/schema.org.cy.js
+++ b/ui/cypress/e2e/schema.org.cy.js
@@ -1,3 +1,6 @@
+// Cypress does weird things with the JSON/LD in the document head
+// so this is a way of extracting and removing odd additional chars that .text() produces etc. There's probably a better way
+// of doing this but none is forthcoming in the docs
 const parseJsonSchema = (elem) =>
   JSON.parse(
     JSON.stringify(elem.text())

--- a/ui/cypress/e2e/schema.org.cy.js
+++ b/ui/cypress/e2e/schema.org.cy.js
@@ -1,0 +1,28 @@
+const parseJsonSchema = (elem) =>
+  JSON.parse(
+    JSON.stringify(elem.text()).replaceAll('&quot;', '"').trim().slice(1, -1)
+  );
+
+describe('Schema.org representations', () => {
+  describe('WebPage', () => {
+    it('Should produce a schema.org webpage entity in the head', () => {
+      cy.visit('/help-and-resources');
+      cy.document()
+        .get('head script[class="structured-data-list"]')
+        .then((jsonSchema) => {
+          expect(jsonSchema).to.have.attr('type', 'application/ld+json');
+          expect(parseJsonSchema(jsonSchema)).to.deep.equal({
+            '@context': 'https://schema.org/',
+            '@type': 'WebPage',
+            title: 'Help and resources',
+            description:
+              'Explore resources for the data standards community in health and social care including links to discussion forums and government regulations.',
+            url: `${Cypress.config().baseUrl}/help-and-resources`.replace(
+              /^https?:\/\//,
+              ''
+            ),
+          });
+        });
+    });
+  });
+});

--- a/ui/helpers/getHost.js
+++ b/ui/helpers/getHost.js
@@ -1,0 +1,3 @@
+export async function getHost({ headers }) {
+  return headers.host || null;
+}

--- a/ui/helpers/getPageProps.js
+++ b/ui/helpers/getPageProps.js
@@ -1,9 +1,10 @@
 import { list, schema, getPages } from './api';
-
-export async function getPageProps({ query }, options = {}) {
+import { getHost } from './getHost';
+export async function getPageProps({ req, query }, options = {}) {
   return {
     props: {
       ...{
+        host: await getHost(req),
         data: await list(query),
         schemaData: await schema(),
         pages: await getPages(),

--- a/ui/helpers/getPageProps.js
+++ b/ui/helpers/getPageProps.js
@@ -3,13 +3,11 @@ import { getHost } from './getHost';
 export async function getPageProps({ req, query }, options = {}) {
   return {
     props: {
-      ...{
-        host: await getHost(req),
-        data: await list(query),
-        schemaData: await schema(),
-        pages: await getPages(),
-        searchTerm: query.q || '',
-      },
+      host: await getHost(req),
+      data: await list(query),
+      schemaData: await schema(),
+      pages: await getPages(),
+      searchTerm: query.q || '',
       ...options,
     },
   };

--- a/ui/pages/[page].js
+++ b/ui/pages/[page].js
@@ -3,10 +3,20 @@ import DOMPurify from 'isomorphic-dompurify';
 import { fromMarkdown } from 'mdast-util-from-markdown';
 import { getPages } from '../helpers/api';
 import { Page, TableOfContents, CookiesTable } from '../components';
+import { getHost } from '../helpers/getHost';
+getHost;
 
-const StaticPage = ({ content, showToc, title, parsed, description, page }) => {
+const StaticPage = ({
+  content,
+  showToc,
+  title,
+  parsed,
+  description,
+  page,
+  host,
+}) => {
   return (
-    <Page title={title} description={description}>
+    <Page title={title} description={description} host={host}>
       <div className="nhsuk-grid-row">
         {showToc && <TableOfContents content={parsed} />}
         <div className="nhsuk-grid-column-two-thirds">
@@ -20,6 +30,7 @@ const StaticPage = ({ content, showToc, title, parsed, description, page }) => {
 };
 
 export async function getServerSideProps(context) {
+  const { req } = context;
   const { page } = context.params;
   const pages = await getPages();
   const pageData = pages.filter((i) => i.name === page).pop();
@@ -41,6 +52,7 @@ export async function getServerSideProps(context) {
 
   return {
     props: {
+      host: await getHost(req),
       pages,
       showToc,
       description,

--- a/ui/pages/[page].js
+++ b/ui/pages/[page].js
@@ -4,7 +4,6 @@ import { fromMarkdown } from 'mdast-util-from-markdown';
 import { getPages } from '../helpers/api';
 import { Page, TableOfContents, CookiesTable } from '../components';
 import { getHost } from '../helpers/getHost';
-getHost;
 
 const StaticPage = ({
   content,

--- a/ui/pages/current-standards/index.js
+++ b/ui/pages/current-standards/index.js
@@ -12,13 +12,14 @@ import {
 } from '../../components';
 import { getPageProps } from '../../helpers/getPageProps';
 
-const pageProps = {
+const staticPageProps = {
   title: 'Current standards',
   description:
     'Find published data standards for health and social care including standards required for use in England.',
 };
 
-export default function Standards({ data, schemaData }) {
+export default function Standards({ data, schemaData, host }) {
+  const pageProps = { ...staticPageProps, host };
   return (
     <Page {...pageProps}>
       <h1>

--- a/ui/pages/future-standards.js
+++ b/ui/pages/future-standards.js
@@ -17,13 +17,13 @@ import {
 
 import styles from '../styles/Roadmap.module.scss';
 
-const pageProps = {
+const staticPageProps = {
   title: 'Future standards',
   description:
     'Find data standards proposed or in development as future requirements for health and social care services in England.',
 };
 
-export default function Roadmap({ data, schemaData }) {
+export default function Roadmap({ data, schemaData, ...props }) {
   const [results, setResults] = useState(data.results);
   const [count, setCount] = useState(data.count || 0);
   const [loading, setLoading] = useState(false);
@@ -63,6 +63,8 @@ export default function Roadmap({ data, schemaData }) {
     ? activeFilters.care_setting.length
     : 0;
   const resultSummary = `${count} result${count === 1 ? '' : 's'}`;
+
+  const pageProps = { ...staticPageProps, ...props };
 
   return (
     <Page {...pageProps}>
@@ -109,7 +111,7 @@ export default function Roadmap({ data, schemaData }) {
 
 export async function getServerSideProps(context) {
   const { id, defaultSort } = schema.find((s) => s.defaultSort);
-  return getPageProps({
+  return getPageProps(context, {
     query: {
       sort: {
         [id]: defaultSort,

--- a/ui/pages/index.js
+++ b/ui/pages/index.js
@@ -11,8 +11,9 @@ import {
 import styles from '../styles/Home.module.scss';
 import { getPages } from '../helpers/api';
 import { list } from '../helpers/api';
+import { useContentContext } from '../context';
 
-const content = {
+const staticPageContent = {
   header: 'Find standards to record, handle and exchange data in England',
   description:
     'Find data standards for health and social care in England, including standards for clinical and care information, APIs and draft standards in development.',
@@ -61,10 +62,12 @@ const HomeElement = ({ link, linkText, description }) => (
   </div>
 );
 
-export default function Home({ pages }) {
+export default function Home({ pages, host, ...props }) {
+  const { contentMerge } = useContentContext();
+  const pageContent = contentMerge(staticPageContent);
   const standardsPage = 'current-standards';
   return (
-    <Page description={content.description}>
+    <Page description={pageContent.description} host={host} {...props}>
       <HomeSection
         title="Browse by care setting"
         link={`/${standardsPage}`}
@@ -209,7 +212,7 @@ export async function getServerSideProps() {
     props: {
       recent: recent.results.slice(0, 3),
       pages,
-      content,
+      content: staticPageContent,
     },
   };
 }

--- a/ui/pages/search-results.js
+++ b/ui/pages/search-results.js
@@ -23,7 +23,7 @@ const content = {
   },
 };
 
-export default function SearchResults({ data, schemaData }) {
+export default function SearchResults({ data, schemaData, host }) {
   const { query } = useQueryContext();
   const { q: searchTerm } = query;
   const title = searchTerm
@@ -31,7 +31,7 @@ export default function SearchResults({ data, schemaData }) {
     : content.title;
 
   return (
-    <Page title={`${title} - NHS Standards Directory`}>
+    <Page title={`${title} - NHS Standards Directory`} host={host}>
       <h1>
         <Snippet inline>title</Snippet>
       </h1>

--- a/ui/pages/site-map.js
+++ b/ui/pages/site-map.js
@@ -3,7 +3,6 @@ import { Page } from '../components';
 import Link from 'next/link';
 import { getPages } from '../helpers/api';
 import { getHost } from '../helpers/getHost';
-getHost;
 
 const SiteMap = ({ pages, host }) => {
   const feedbackLink =

--- a/ui/pages/site-map.js
+++ b/ui/pages/site-map.js
@@ -2,8 +2,10 @@ import { Fragment } from 'react';
 import { Page } from '../components';
 import Link from 'next/link';
 import { getPages } from '../helpers/api';
+import { getHost } from '../helpers/getHost';
+getHost;
 
-const SiteMap = ({ pages }) => {
+const SiteMap = ({ pages, host }) => {
   const feedbackLink =
     'https://docs.google.com/forms/d/e/1FAIpQLSc3t0kyD6f8kkvgRnqtj5uUmozq_oACBWrOqhrDBmzzqlfRHA/viewform';
 
@@ -148,10 +150,12 @@ const SiteMap = ({ pages }) => {
     'about-this-service',
   ].map((page) => pages.find((p) => p.name === page));
 
-  const pageProps = {
+  const staticPageProps = {
     title: 'Site map',
     description: 'View a complete list of pages in our website.',
   };
+
+  const pageProps = { ...staticPageProps, host };
 
   return (
     <Page {...pageProps}>
@@ -188,26 +192,28 @@ const SiteMap = ({ pages }) => {
 
             {orderedPages.map((page, index) => {
               return (
-                <li key={index}>
-                  <p>
-                    <Link href={`/${page.name}`}>
-                      <a>{page.short_title || page.title}</a>
-                    </Link>
-                  </p>
-                  {children[page.name] && (
-                    <ul>
-                      {children[page.name].map((child, index) => {
-                        return (
-                          <li key={index}>
-                            <Link href={`/${page.name}#${child.anchor}`}>
-                              <a>{child.title}</a>
-                            </Link>
-                          </li>
-                        );
-                      })}
-                    </ul>
-                  )}
-                </li>
+                page && (
+                  <li key={index}>
+                    <p>
+                      <Link href={`/${page.name}`}>
+                        <a>{page.short_title || page.title}</a>
+                      </Link>
+                    </p>
+                    {children[page.name] && (
+                      <ul>
+                        {children[page.name].map((child, index) => {
+                          return (
+                            <li key={index}>
+                              <Link href={`/${page.name}#${child.anchor}`}>
+                                <a>{child.title}</a>
+                              </Link>
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    )}
+                  </li>
+                )
               );
             })}
             <li>
@@ -224,11 +230,12 @@ const SiteMap = ({ pages }) => {
 
 export default SiteMap;
 
-export async function getServerSideProps() {
+export async function getServerSideProps({ req }) {
   const pages = await getPages();
 
   return {
     props: {
+      host: await getHost(req),
       pages,
     },
   };


### PR DESCRIPTION
In addition to DataSet schema annotations for individual standards pages, this introduces basic WebPage schemas for all pages. This includes a `contactPoint` and the page description.

```js
{ 
    '@context': 'https://schema.org/',
    '@type': 'WebPage',
    contactPoint: {
        '@type': 'ContactPoint',
        email: 'england.interop.standards@nhs.net',
    },
    title: 'Help and resources',
    description:
        'Explore resources for the data standards community in health and social care including links to discussion forums and government regulations.',
    url: {BASE_URL}/help-and-resources
}
```