### PR TITLE
[STAN-1031] link the email on future standards

### DIFF
--- a/ui/pages/future-standards.js
+++ b/ui/pages/future-standards.js
@@ -73,8 +73,10 @@ export default function Roadmap({ data, schemaData, ...props }) {
         <p>
           Find standards being assessed by the Data Alliance Partnership Board
           with a view to mandatory implementation in England. For more
-          information or to propose a new standard email
-          england.interop.standards@nhs.net
+          information or to propose a new standard email{' '}
+          <a href="mailto:england.interop.standards@nhs.net">
+            england.interop.standards@nhs.net
+          </a>
         </p>
         <p>
           <strong>{resultSummary}</strong>


### PR DESCRIPTION
# Madness!
The email link on the future standards page exists but is _**not linked!**_

# Sadness!

<img width="716" alt="Capture d’écran 2022-10-21 à 10 58 35" src="https://user-images.githubusercontent.com/120181/197156908-1afefd84-2aab-4fe3-91b4-8cddb3740c07.png">

Regard the sorry state of the email address, lurking like so much unadorned hypertext flotsam free floating in cyberspace

# Gladness!
<img width="700" alt="Capture d’écran 2022-10-21 à 10 58 25" src="https://user-images.githubusercontent.com/120181/197157050-7de01181-3c07-4c97-8010-9585fd5acf0d.png">

Experience the updated functionality of a comprehensively linked email address in our digital estate.

**Featuring:**
* classic blue text colour 
* classic blue underline as text decoration
* a functioning "mailto" destination which matches that which is visually presented
* 100% guaranteed conversion rate between clicks to emails sent