### PR TITLE
[STAN-861] Allow for multiple standard types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,8 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "workbench.colorTheme": "One Monokai",
   "workbench.preferredDarkColorTheme": "One Monokai",
-  "editor.tabSize": 2
+  "editor.tabSize": 2,
+  "[dockerfile]": {
+    "editor.defaultFormatter": "ms-azuretools.vscode-docker"
+  }
 }

--- a/ui/components/Dataset/index.js
+++ b/ui/components/Dataset/index.js
@@ -50,17 +50,12 @@ function Model({ model }) {
       </p>
       <Flex className="nhsuk-body-s">
         <p className={classnames('nhsuk-body-s', styles.noBottom)}>
-          Type: {standard_category}
-        </p>
-        <p className={classnames('nhsuk-body-s', styles.noBottom)}>
           Status:{' '}
           <Tag type={status} classes="nhsuk-body-s">
             {status}
           </Tag>
         </p>
-        <p
-          className={classnames('nhsuk-body-s', styles.right, styles.noBottom)}
-        >
+        <p className={classnames('nhsuk-body-s', styles.noBottom)}>
           Date added: {formatDate(metadata_created)}
         </p>
       </Flex>
@@ -125,7 +120,12 @@ const CheckBox = () => {
   };
 
   return (
-    <div className={classnames('nhsuk-checkboxes__item', styles.checkboxItem)}>
+    <div
+      className={classnames(
+        'nhsuk-checkboxes__item nhsuk-u-margin-bottom-4',
+        styles.checkboxItem
+      )}
+    >
       <input
         className="nhsuk-checkboxes__input nhsuk-u-font-size-16"
         id="mandated"

--- a/ui/components/Dataset/index.js
+++ b/ui/components/Dataset/index.js
@@ -28,14 +28,7 @@ function Embolden({ children }) {
 }
 
 function Model({ model }) {
-  const {
-    name,
-    status,
-    title,
-    metadata_created,
-    standard_category,
-    description,
-  } = model;
+  const { name, status, title, metadata_created, description } = model;
   const target = `/current-standards/${name}`;
 
   return (

--- a/ui/components/Flex/style.module.scss
+++ b/ui/components/Flex/style.module.scss
@@ -1,9 +1,8 @@
 .flex {
   display: flex;
-  justify-content: space-between;
 
   > * {
-    margin-right: 20px;
+    margin-right: 40px;
     &:last-child {
       margin-right: 0;
     }

--- a/ui/components/Model/index.js
+++ b/ui/components/Model/index.js
@@ -20,6 +20,7 @@ const Rows = (props) => {
       ) : (
         format(props)
       )}
+      {options.more && options.more}
     </dd>
   );
 };

--- a/ui/schema/index.js
+++ b/ui/schema/index.js
@@ -34,6 +34,37 @@ function TruncateLink({ link, email }) {
   return <a href={email ? `mailto:${link}` : link}>{truncate(link, 50)}</a>;
 }
 
+const CategoryDetails = function () {
+  return (
+    <Details
+      className="nhsuk-u-font-size-16 nhsuk-u-margin-top-4"
+      summary="What this type means"
+    >
+      <div className="nhsuk-details__text">
+        <Paragraph>
+          <strong>Record standards</strong> define what information to collect
+          and how to format it, for example when registering a new patient.
+        </Paragraph>
+        <Paragraph>
+          <strong>Data definitions and terminologies</strong> define the format
+          of individual data items so they can be consistently represented, for
+          example dates or medication names. Reference sets and controlled lists
+          are also included.
+        </Paragraph>
+        <Paragraph>
+          <strong>Technical standards and specifications</strong> specify how to
+          make information available technically including how the data is
+          structured and transported.
+        </Paragraph>
+        <Paragraph>
+          <strong>Information codes of practice</strong> are legal or best
+          practice guidelines on how information should be handled.
+        </Paragraph>
+      </div>
+    </Details>
+  );
+};
+
 const schema = [
   {
     section_title: 'About this standard',
@@ -76,40 +107,7 @@ const schema = [
     },
     standard_category: {
       label: 'Type',
-      format: (val) => (
-        <>
-          {val}
-          {
-            <Details
-              className="nhsuk-u-font-size-16 nhsuk-u-margin-top-4"
-              summary="What this type means"
-            >
-              <div className="nhsuk-details__text">
-                <Paragraph>
-                  <strong>Record standards</strong> define what information to
-                  collect and how to format it, for example when registering a
-                  new patient.
-                </Paragraph>
-                <Paragraph>
-                  <strong>Data definitions and terminologies</strong> define the
-                  format of individual data items so they can be consistently
-                  represented, for example dates or medication names. Reference
-                  sets and controlled lists are also included.
-                </Paragraph>
-                <Paragraph>
-                  <strong>Technical standards and specifications</strong>{' '}
-                  specify how to make information available technically
-                  including how the data is structured and transported.
-                </Paragraph>
-                <Paragraph>
-                  <strong>Information codes of practice</strong> are legal or
-                  best practice guidelines on how information should be handled.
-                </Paragraph>
-              </div>
-            </Details>
-          }
-        </>
-      ),
+      more: <CategoryDetails />,
     },
     documentation_help_text: {
       label: 'Documentation',


### PR DESCRIPTION
1. We can now display multiple standard types on standard pages
<img width="748" alt="Capture d’écran 2022-10-21 à 17 23 31" src="https://user-images.githubusercontent.com/120181/197232243-199ceccd-905e-4480-8427-2c24da27a119.png">

...but it still works with a single category

<img width="598" alt="Capture d’écran 2022-10-21 à 17 20 11" src="https://user-images.githubusercontent.com/120181/197232257-dd95f2c3-767f-4fce-8a94-912119788231.png">

2. Cleans up spacing under mandated checkbox 

before:
<img width="387" alt="Capture d’écran 2022-10-21 à 16 59 56" src="https://user-images.githubusercontent.com/120181/197232263-2fd9afd1-0772-489d-bd46-93dc54927928.png">

after:
<img width="469" alt="Capture d’écran 2022-10-21 à 17 00 02" src="https://user-images.githubusercontent.com/120181/197232261-89c4002b-f00d-4797-826b-9f779eca9608.png">

3. Future standards page