### PR TITLE
Send correct argument structure to `getPageProps` function

### DIFF
--- a/ui/pages/future-standards.js
+++ b/ui/pages/future-standards.js
@@ -99,7 +99,8 @@ export default function Roadmap({ data, schemaData, page }) {
 
 export async function getServerSideProps(context) {
   const { id, defaultSort } = schema.find((s) => s.defaultSort);
-  const pageProps = await getPageProps(context, {
+  const pageProps = await getPageProps({
+    ...context,
     query: {
       sort: {
         [id]: defaultSort,


### PR DESCRIPTION
The `query` object should be a property of the first argument to `getPageProps`. Passing the query as it was means it is ignored by the `list` function and therefore returns all standards rather than only incative on initial page load.