### PR TITLE
use our own versions of dataset and org schemas

### DIFF
--- a/Dockerfile-ckan
+++ b/Dockerfile-ckan
@@ -22,8 +22,8 @@ ENV CKAN__PLUGINS envvars image_view text_view recline_view datastore datapusher
 
 # Configure ckan
 RUN ckan config-tool ${APP_DIR}/production.ini "ckan.plugins = ${CKAN__PLUGINS}"
-RUN ckan config-tool ${APP_DIR}/production.ini "scheming.dataset_schemas = ckanext.scheming:ckan_dataset.yaml"
-RUN ckan config-tool ${APP_DIR}/production.ini "scheming.organization_schemas = ckanext.scheming:org_with_email.json"
+RUN ckan config-tool ${APP_DIR}/production.ini "scheming.dataset_schemas = ckanext.scheming:nhs_dataset.yaml"
+RUN ckan config-tool ${APP_DIR}/production.ini "scheming.organization_schemas = ckanext.scheming:nhs_org.json"
 RUN ckan config-tool ${APP_DIR}/production.ini "ckanext.pages.allow_html = true"
 # https://docs.ckan.org/en/2.9/maintaining/tracking.html
 RUN ckan config-tool ${APP_DIR}/production.ini "ckan.tracking_enabled = true"


### PR DESCRIPTION
I've pushed two new schemas to the Marvell fork of [ckanext-scheming](https://github.com/Marvell-Consulting/ckanext-scheming/commits/master). 
This change allows us to push our own changes without fear of the example schemas being overriden by merges from the upstream ckan-scheming project.

Should've done this ages ago!