### PR TITLE
STAN-1097 "content" not "value" in meta descriptions

### DIFF
--- a/ui/components/Page/index.js
+++ b/ui/components/Page/index.js
@@ -10,7 +10,7 @@ export default function Page({ children, host, description, title }) {
       <WebPageSchema title={title} description={description} host={host} />
       <Head>
         <title>{pageTitle}</title>
-        {description && <meta name="description" value={description} />}
+        {description && <meta name="description" content={description} />}
       </Head>
       {children}
     </>


### PR DESCRIPTION
https://developers.google.com/search/docs/appearance/snippet#use-quality-descriptions

We accidentally added 'value', which is normal for meta tags, but 'content' is expected by google et al