### PR TITLE
[STAN-1107] Add password auth to Redis

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -97,6 +97,7 @@ jobs:
             --set ckan.db.ckanDbUrl='${{ secrets.DB_HOST }}'
             --set ckan.datastore.RwDbUrl='${{ secrets.DB_HOST }}'
             --set ckan.datastore.RoDbUrl='${{ secrets.DB_HOST }}'
+            --set redis.auth.password='${{ secrets.REDIS_PASSWORD }}'
             --set image.repository=$ECR_REGISTRY/$ECR_REPOSITORY
             --set image.tag=$IMAGE_TAG
             --set ckan.psql.initialize=false

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -80,6 +80,7 @@ jobs:
             --set ckan.db.ckanDbUrl='${{ secrets.DB_HOST }}'
             --set ckan.datastore.RwDbUrl='${{ secrets.DB_HOST }}'
             --set ckan.datastore.RoDbUrl='${{ secrets.DB_HOST }}'
+            --set redis.auth.password='${{ secrets.REDIS_PASSWORD }}'
             --set image.repository=$ECR_REGISTRY/$ECR_REPOSITORY
             --set image.tag=$IMAGE_TAG
             --set postgresql.enabled=false

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -77,6 +77,7 @@ jobs:
             --set ckan.db.ckanDbUrl='${{ secrets.DB_HOST }}'
             --set ckan.datastore.RwDbUrl='${{ secrets.DB_HOST }}'
             --set ckan.datastore.RoDbUrl='${{ secrets.DB_HOST }}'
+            --set redis.auth.password='${{ secrets.REDIS_PASSWORD }}'
             --set image.repository=$ECR_REGISTRY/$ECR_REPOSITORY
             --set image.tag=$IMAGE_TAG
             --set ckan.psql.initialize=false

--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -40,6 +40,9 @@ CkanDBName: &CkanDBName ckan_default
 CkanDBUser: &CkanDBUser ckan_default
 # CkanDBPass -- Variable for password for the CKAN database owner
 CkanDBPass: &CkanDBPass pass
+
+# RedisPassword variable
+RedisPassword: &RedisPassword pass
 # DatastoreDBName -- Variable for name of the database used by Datastore
 DatastoreDBName: &DatastoreDBName datastore_default
 # DatastoreRWDBUser -- Variable for username for the user with write access to the datastore database
@@ -257,7 +260,11 @@ redis:
       # redis.master.persistence.size -- Size of the volume claim
       size: 1Gi
   # redis.usePassword -- Use password for accessing redis
-  usePassword: false
+  # usePassword: true
+  auth:
+    enabled: true
+    password: *RedisPassword
+
 
 solr:  
   # Please see all available overrides at https://github.com/helm/charts/tree/master/incubator/solr


### PR DESCRIPTION
- Sets password protection to `true`
- Adds password passthrough into all deployments
- values.yaml should now receieve redis password values
- A value for `REDIS_PASSWORD` has been added to all environments