### PR TITLE
[STAN-1110] set USER to node in ui Dockerfile

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -4,12 +4,14 @@ WORKDIR /app
 
 RUN apk upgrade --no-cache
 
-COPY package.json /app/package.json
-COPY package-lock.json /app/package-lock.json
+COPY --chown=node:node . /app
+
+RUN touch .env.production
+RUN chown node:node .env.production
+
+USER node
 
 RUN npm ci --production --include-optional --ignore-scripts
-
-COPY . /app
 
 ARG NEXT_PUBLIC_TAG_ID
 ARG NEXT_PUBLIC_TRACKING_ID


### PR DESCRIPTION
* Previously we weren't declaring a USER in our UI build, meaning root was left available
* This changes the build to run using the `node` user