### PR TITLE
[STAN-1110] always create node_modules

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -4,14 +4,17 @@ WORKDIR /app
 
 RUN apk upgrade --no-cache
 
-COPY --chown=node:node . /app
+RUN mkdir node_modules && chown node:node node_modules
+RUN touch .env.production && chown node:node .env.production
 
-RUN touch .env.production
-RUN chown node:node .env.production
+COPY --chown=node:node package.json /app/package.json
+COPY --chown=node:node package-lock.json /app/package-lock.json
 
 USER node
 
 RUN npm ci --production --include-optional --ignore-scripts
+
+COPY --chown=node:node . /app
 
 ARG NEXT_PUBLIC_TAG_ID
 ARG NEXT_PUBLIC_TRACKING_ID

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -4,13 +4,11 @@ WORKDIR /app
 
 RUN apk upgrade --no-cache
 
-RUN mkdir node_modules && chown node:node node_modules
+
 RUN touch .env.production && chown node:node .env.production
 
-COPY --chown=node:node package.json /app/package.json
-COPY --chown=node:node package-lock.json /app/package-lock.json
-
-USER node
+COPY package.json /app/package.json
+COPY package-lock.json /app/package-lock.json
 
 RUN npm ci --production --include-optional --ignore-scripts
 
@@ -27,5 +25,7 @@ RUN echo "NEXT_PUBLIC_TRACKING_ID=${NEXT_PUBLIC_TRACKING_ID}" >> .env.production
 RUN echo "NEXT_PUBLIC_SITE_CODE=${NEXT_PUBLIC_SITE_CODE}" >> .env.production
 
 RUN npm run build --production  --if-present
+
+USER node
 
 CMD npm start


### PR DESCRIPTION
Deploy dev fails with an EACCESS issue for creating `node_modules`: https://github.com/nhsx/standards-registry/actions/runs/3409968479/jobs/5672369479#step:6:64

This creates and `chown`s the `node_modules` folder before running the usual installation steps