### PR TITLE
[STAN-1047] Add aria current=page to pagination

### DIFF
--- a/ui/components/Cookies/index.js
+++ b/ui/components/Cookies/index.js
@@ -16,7 +16,12 @@ export const Cookies = ({ choice }) => {
 
   return (
     (!consentChoice && (
-      <div id="nhsuk-cookie-banner" data-nosnippet="true">
+      <div
+        id="nhsuk-cookie-banner"
+        role="alertdialog"
+        aria-label="Cookie consent banner"
+        data-nosnippet="true"
+      >
         <div
           className={classnames('nhsuk-cookie-banner', styles.banner)}
           id="cookiebanner"

--- a/ui/components/Pagination/index.js
+++ b/ui/components/Pagination/index.js
@@ -73,6 +73,7 @@ export default function Pagination({ limit = 10, count }) {
               })}
             >
               <a
+                aria-current={page === num + 1 ? 'page' : null}
                 aria-label={`Goto Page ${num + 1}`}
                 className={classnames(styles.link, {
                   [styles.current]: page === num + 1,

--- a/ui/cypress/e2e/standards/list.cy.js
+++ b/ui/cypress/e2e/standards/list.cy.js
@@ -12,7 +12,7 @@ describe('Standards Listing Index', () => {
     cy.get('#browse-results li').should('have.length', 10);
   });
 
-  it.only('Should pass basic a11y check', () => {
+  it('Should pass basic a11y check', () => {
     cy.visit(`/published-standards`);
     // make sure main content area is loaded before injecting a11y checker
     cy.get('[role="main"]');

--- a/ui/cypress/e2e/standards/list.cy.js
+++ b/ui/cypress/e2e/standards/list.cy.js
@@ -12,6 +12,14 @@ describe('Standards Listing Index', () => {
     cy.get('#browse-results li').should('have.length', 10);
   });
 
+  it.only('Should pass basic a11y check', () => {
+    cy.visit(`/published-standards`);
+    // make sure main content area is loaded before injecting a11y checker
+    cy.get('[role="main"]');
+    cy.injectAxe();
+    cy.checkA11y(null, null, a11yLog);
+  });
+
   describe.only('filters and pagination', () => {
     it('Can change page', () => {
       cy.visit('/published-standards');

--- a/ui/helpers/api.js
+++ b/ui/helpers/api.js
@@ -16,8 +16,8 @@ async function callApi(url) {
 
     return result;
   } catch (err) {
-    const message = err.response.data;
-    console.error(message);
+    console.warn('error trying to call', url);
+    console.error(err);
   }
 }
 


### PR DESCRIPTION

<img width="1495" alt="Capture d’écran 2022-11-08 à 12 07 53" src="https://user-images.githubusercontent.com/120181/200549399-56efbd70-a11f-4f90-8ecf-156055ee5fa4.png">


Also some 🏡🧹
* adds `alertdialog` role to cookie banner callout
* gives cookie banner a readable aria label
* adds a11y check to listings page with a content check before injecting the checker (stops race conditions)
* Adds full console error for api request failures

