### PR TITLE
[STAN-737] shorter placeholder text

### DIFF
--- a/ui/pages/index.js
+++ b/ui/pages/index.js
@@ -169,11 +169,7 @@ export function HomepageHero({ recent }) {
             <Snippet inline>header</Snippet>
           </h1>
           <Snippet large>intro</Snippet>
-          <Search
-            placeholder="For example, FHIR, allergies, GP"
-            navigate
-            homepage
-          />
+          <Search placeholder="Search published standards" navigate homepage />
         </div>
         <div className="nhsuk-grid-column-one-third">
           <div className={styles.sidebar}>

--- a/ui/pages/published-standards/index.js
+++ b/ui/pages/published-standards/index.js
@@ -38,7 +38,7 @@ export default function Standards({ data, schemaData, host }) {
         <div className="nhsuk-grid-column-three-quarters">
           <Search
             labelText="Search"
-            placeholder="For example, FHIR, allergies, GP"
+            placeholder="Search published standards"
             location="browse"
           />
         </div>

--- a/ui/pages/search-results.js
+++ b/ui/pages/search-results.js
@@ -42,7 +42,7 @@ export default function SearchResults({ data, schemaData, host }) {
         <div className="nhsuk-grid-column-three-quarters">
           <Search
             labelText="Search"
-            placeholder="For example, FHIR, allergies, GP"
+            placeholder="Search published standards"
             location="browse"
           />
         </div>


### PR DESCRIPTION
* Avoids reflow issues for people using highly magnified version of the page

### Published standards Before
<img width="756" alt="Capture d’écran 2022-11-08 à 13 49 21" src="https://user-images.githubusercontent.com/120181/200568470-faac0dd7-8baf-4f4c-b0cf-ff6fb92fbf01.png">

### Published standards After
<img width="754" alt="Capture d’écran 2022-11-08 à 13 49 30" src="https://user-images.githubusercontent.com/120181/200568463-aa363c86-bb95-4364-b792-5be6cbb39718.png">

### Home before
<img width="670" alt="Capture d’écran 2022-11-08 à 13 49 11" src="https://user-images.githubusercontent.com/120181/200568474-b46f2535-9e9b-4a51-9b7c-20260c0f3d03.png">

### Home after
<img width="696" alt="Capture d’écran 2022-11-08 à 13 49 06" src="https://user-images.githubusercontent.com/120181/200568480-8fddb381-d0ed-4064-ad2e-eb692e874e30.png">

### Reflow before
<img width="1193" alt="Capture d’écran 2022-11-08 à 13 56 43" src="https://user-images.githubusercontent.com/120181/200570553-52e37c59-571a-404e-855a-dc16a7932fe8.png">

### No reflow after
<img width="1197" alt="Capture d’écran 2022-11-08 à 13 56 50" src="https://user-images.githubusercontent.com/120181/200570563-64883720-899e-4c78-b151-6cc769f0484e.png">
