### PR TITLE
[STAN-1093] Add basic accessibility checking to most pages

### DIFF
--- a/ui/components/Table/index.js
+++ b/ui/components/Table/index.js
@@ -53,12 +53,15 @@ export function Th({ children, sortable, col, defaultSort }) {
     }
   }
 
+  const ariaSortLabel = { asc: 'ascending', desc: 'descending' };
+
   return (
     <th
       className={classnames(styles.th)}
       role="columnheader"
+      aria-label={`${children} heading`}
       scope="col"
-      aria-sort={orderBy === col ? order : 'none'}
+      aria-sort={orderBy === col ? ariaSortLabel[order] : 'none'}
     >
       {sortable ? (
         <a href="#" onClick={onClick}>

--- a/ui/components/TableOfContents/index.js
+++ b/ui/components/TableOfContents/index.js
@@ -29,8 +29,8 @@ export const TableOfContents = ({ content }) => {
   const minDepth = Math.min(...depths);
 
   return (
-    <div className="nhsuk-grid-column-one-third">
-      <h3 className="nhsuk-heading-s">Contents</h3>
+    <>
+      <h2 className="nhsuk-heading-s">Contents</h2>
       <ul className="nhsuk-list-bullet">
         {headings.map((heading, i) => {
           const { depth, children } = heading;
@@ -42,6 +42,6 @@ export const TableOfContents = ({ content }) => {
           );
         })}
       </ul>
-    </div>
+    </>
   );
 };

--- a/ui/cypress/e2e/a11y-basic.cy.js
+++ b/ui/cypress/e2e/a11y-basic.cy.js
@@ -1,0 +1,35 @@
+import { a11yLog, failLevel } from '../support/custom';
+
+describe('Page a11y', () => {
+  describe('Homepage', () => {
+    it('passes a11y', () => {
+      cy.visit('/');
+      cy.get('[role="main"]');
+      cy.get('h1');
+      cy.injectAxe();
+      cy.wait(100);
+      cy.checkA11y(null, null, a11yLog);
+    });
+  });
+
+  describe('Future Standards', () => {
+    it('passes a11y', () => {
+      cy.visit('/future-standards');
+      cy.get('[role="main"]');
+      cy.get('h1');
+      cy.injectAxe();
+      cy.wait(100);
+      cy.checkA11y(null, null, a11yLog);
+
+      cy.get('th a').first().click();
+      cy.checkA11y(null, null, a11yLog);
+      cy.get('th a').first().click();
+      cy.checkA11y(null, null, a11yLog);
+      cy.get('th a').click({ multiple: true });
+      cy.checkA11y(null, null, a11yLog);
+    });
+  });
+
+  describe('Static Pages', () => {});
+  describe('Published Standards', () => {});
+});

--- a/ui/cypress/e2e/a11y-basic.cy.js
+++ b/ui/cypress/e2e/a11y-basic.cy.js
@@ -1,4 +1,4 @@
-import { a11yLog, failLevel } from '../support/custom';
+import { a11yLog } from '../support/custom';
 
 describe('Page a11y', () => {
   describe('Homepage', () => {
@@ -7,6 +7,7 @@ describe('Page a11y', () => {
       cy.get('[role="main"]');
       cy.get('h1');
       cy.injectAxe();
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(100);
       cy.checkA11y(null, null, a11yLog);
     });
@@ -18,6 +19,7 @@ describe('Page a11y', () => {
       cy.get('[role="main"]');
       cy.get('h1');
       cy.injectAxe();
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(100);
       cy.checkA11y(null, null, a11yLog);
 
@@ -30,6 +32,24 @@ describe('Page a11y', () => {
     });
   });
 
-  describe('Static Pages', () => {});
-  describe('Published Standards', () => {});
+  describe('Static Pages', () => {
+    [
+      '/about-standards',
+      '/help-and-resources',
+      '/accessibility-statement',
+      '/cookie-policy',
+      '/about-this-service',
+      '/privacy-policy',
+    ].forEach((page) => {
+      it(`${page.replace('-', ' ').replace('/', '')} passes a11y check`, () => {
+        cy.visit(page);
+        cy.get('[role="main"]');
+        cy.get('h1');
+        cy.injectAxe();
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(100);
+        cy.checkA11y(null, null, a11yLog);
+      });
+    });
+  });
 });

--- a/ui/pages/[page].js
+++ b/ui/pages/[page].js
@@ -17,9 +17,18 @@ const StaticPage = ({
   return (
     <Page title={title} description={description} host={host}>
       <div className="nhsuk-grid-row">
-        {showToc && <TableOfContents content={parsed} />}
+        <div className="nhsuk-grid-column-one-third">
+          <br />
+        </div>
         <div className="nhsuk-grid-column-two-thirds">
           <h1>{title}</h1>
+        </div>
+        {showToc && (
+          <div className="nhsuk-grid-column-one-third">
+            <TableOfContents content={parsed} />
+          </div>
+        )}
+        <div className="nhsuk-grid-column-two-thirds">
           <div dangerouslySetInnerHTML={{ __html: content }} />
           {page === 'cookie-policy' && <CookiesTable />}
         </div>


### PR DESCRIPTION
### [Adds top level a11y checks](https://github.com/nhsx/standards-registry/commit/828b0f179534c0e7b9074389c138a132758828e8) 

* Auditing future standards brought up an aria value violation
* have added clickthroughs with checks for those values
* wait seems to, begrudgingly, be necessary to avoid race conditions

### [Reorders static pages, tests for a11y](https://github.com/nhsx/standards-registry/commit/a446e1fba6781042522063264555ebbde2b53bef)

The a11y checker made a reasonable point about heading order in our static pages.
I've shuffled the content in those pages so that the table on contents comes after the page title:

#### Before
<img width="992" alt="Capture d’écran 2022-11-08 à 15 35 37" src="https://user-images.githubusercontent.com/120181/200593354-f04a015f-9a30-436e-aede-ce7068c1c061.png">

#### After

<img width="1030" alt="Capture d’écran 2022-11-08 à 15 35 29" src="https://user-images.githubusercontent.com/120181/200593408-71e1c193-d967-4e75-a35a-0f11a6c3a701.png">

