### PR TITLE
[STAN-1077] honour first value of query in titles

### DIFF
--- a/ui/components/Page/index.js
+++ b/ui/components/Page/index.js
@@ -1,10 +1,23 @@
 import Head from 'next/head';
 import { useContentContext } from '../../context/content';
 import { WebPageSchema } from '../DatasetSchema';
+import { useQueryContext } from '../../context/query';
+
+const getQueryForTitle = (query) => {
+  const joiner = ' - ';
+  const vals = Object.values(query);
+  if (vals.length === 0) {
+    return '';
+  }
+  const queryShift = typeof vals.length > 1 ? vals.shift()[0] : vals.shift();
+  const queryTitle = Array.isArray(queryShift) ? queryShift[0] : queryShift;
+  return [joiner, queryTitle].join('');
+};
 
 export default function Page({ children, host, description, title }) {
+  const { query } = useQueryContext();
   const { setPageTitle } = useContentContext();
-  const pageTitle = setPageTitle(title);
+  const pageTitle = `${setPageTitle(title)}${getQueryForTitle(query)}`;
   return (
     <>
       <WebPageSchema title={title} description={description} host={host} />


### PR DESCRIPTION
In order to indicate to search engines (and users!) that we're in a different view onto published standards content, we're here taking the first care setting/topic filter and appending it to the title.

In the case of multiple topics/care settings, we will still just take the first value as a compromise between being completist and coherent.

<img width="595" alt="Capture d’écran 2022-11-08 à 16 58 13" src="https://user-images.githubusercontent.com/120181/200614304-3b3cc3aa-791b-4c45-b837-cc9333d834a6.png">

<img width="669" alt="Capture d’écran 2022-11-08 à 16 58 34" src="https://user-images.githubusercontent.com/120181/200614302-87b97010-9975-4bf5-a4b0-e8bf475f3bc2.png">

<img width="1193" alt="Capture d’écran 2022-11-08 à 16 59 03" src="https://user-images.githubusercontent.com/120181/200614299-ce5fd436-a227-4586-a73b-a4d4dab8eeda.png">
