### PR TITLE
Quieten various lint warnings

### DIFF
--- a/ui/components/Dataset/index.js
+++ b/ui/components/Dataset/index.js
@@ -189,7 +189,9 @@ export default function Dataset({
     if (pageLoaded) {
       getData();
     }
-  }, [query, pageLoaded]);
+    // we don't want pageLoaded in the dependency array
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query]);
 
   useEffect(() => setPageLoaded(true), []);
 

--- a/ui/components/Dataset/index.js
+++ b/ui/components/Dataset/index.js
@@ -189,7 +189,7 @@ export default function Dataset({
     if (pageLoaded) {
       getData();
     }
-  }, [query]);
+  }, [query, pageLoaded]);
 
   useEffect(() => setPageLoaded(true), []);
 

--- a/ui/components/ResponsiveTable/index.js
+++ b/ui/components/ResponsiveTable/index.js
@@ -49,16 +49,15 @@ export function ResponsiveTable({ schema, results }) {
     });
   }
 
-  let timeout;
-
-  function detectFinish() {
-    clearTimeout(timeout);
-    timeout = setTimeout(setFixedWidths, 100);
-  }
-
   useEffect(() => {
     window.addEventListener('resize', handleWindowResize);
     window.addEventListener('resize', detectFinish);
+
+    let timeout;
+    function detectFinish() {
+      clearTimeout(timeout);
+      timeout = setTimeout(setFixedWidths, 100);
+    }
 
     setFixedWidths();
 

--- a/ui/cypress/e2e/home.cy.js
+++ b/ui/cypress/e2e/home.cy.js
@@ -1,4 +1,4 @@
-import { a11yLog, failLevel } from '../support/custom';
+import { a11yLog } from '../support/custom';
 
 describe('Homepage', () => {
   it('should show home page and call to action', () => {

--- a/ui/pages/future-standards.js
+++ b/ui/pages/future-standards.js
@@ -50,7 +50,9 @@ export default function Roadmap({ data, schemaData, page }) {
       getData();
       setCurrentQuery(query);
     }
-  }, [query, currentQuery, loading]);
+    // we don't want to include loading in the dependency array
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query, currentQuery]);
 
   const activeFilters = omit(query, 'q', 'page', 'orderBy', 'order');
   const numSelected = activeFilters.care_setting

--- a/ui/pages/future-standards.js
+++ b/ui/pages/future-standards.js
@@ -50,7 +50,7 @@ export default function Roadmap({ data, schemaData, page }) {
       getData();
       setCurrentQuery(query);
     }
-  }, [query]);
+  }, [query, currentQuery, loading]);
 
   const activeFilters = omit(query, 'q', 'page', 'orderBy', 'order');
   const numSelected = activeFilters.care_setting


### PR DESCRIPTION
We've been getting consistent warnings about dependencies in `useEffect`, so here I'm adding them in to the dependency array.

More on this here:
https://github.com/facebook/react/issues/14920

Should quieten warnings. Features still work too, which is nice 😎 

