### PR TITLE
[STAN-1180] add permanent redirect from 'current-standards' to 'published-standards'

### DIFF
--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -8,4 +8,13 @@ module.exports = {
   devIndicators: {
     buildActivityPosition: 'bottom-right',
   },
+  async redirects() {
+    return [
+      {
+        source: '/current-standards/:path*',
+        destination: '/published-standards/:path*',
+        permanent: true,
+      },
+    ];
+  },
 };


### PR DESCRIPTION
Passes back a 308 on requests to `current-standards` and any nested path:

```
❯ curl http://localhost:3000/current-standards -v
*   Trying 127.0.0.1:3000...
* Connected to localhost (127.0.0.1) port 3000 (#0)
> GET /current-standards HTTP/1.1
> Host: localhost:3000
> User-Agent: curl/7.79.1
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 308 Permanent Redirect
< Location: /published-standards
< Refresh: 0;url=/published-standards
< Date: Tue, 15 Nov 2022 09:52:21 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
< Transfer-Encoding: chunked
< 
* Connection #0 to host localhost left intact
/published-standards%                                                                                                                             
```

and for `http://localhost:3000/current-standards/systemic-anti-cancer-therapy-data-set`:

```
❯ curl http://localhost:3000/current-standards/systemic-anti-cancer-therapy-data-set -v
*   Trying 127.0.0.1:3000...
* Connected to localhost (127.0.0.1) port 3000 (#0)
> GET /current-standards/systemic-anti-cancer-therapy-data-set HTTP/1.1
> Host: localhost:3000
> User-Agent: curl/7.79.1
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 308 Permanent Redirect
< Location: /published-standards/systemic-anti-cancer-therapy-data-set
< Refresh: 0;url=/published-standards/systemic-anti-cancer-therapy-data-set
< Date: Tue, 15 Nov 2022 09:52:08 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
< Transfer-Encoding: chunked
< 
* Connection #0 to host localhost left intact
/published-standards/systemic-anti-cancer-therapy-data-set%                                                                                       
```