### PR TITLE
[STAN-1196] migration: set strings to booleans

### DIFF
--- a/reader/.eslintrc.cjs
+++ b/reader/.eslintrc.cjs
@@ -1,13 +1,21 @@
 module.exports = {
-    "env": {
-        "browser": true,
-        "es2021": true
+  env: {
+    browser: true,
+    es2021: true,
+  },
+  extends: 'eslint:recommended',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  rules: {},
+  overrides: [
+    {
+      files: ['**/*.test.js'],
+      env: {
+        jest: true, // now **/*.test.js files' env has both es6 *and* jest
+      },
+      plugins: ['jest'],
     },
-    "extends": "eslint:recommended",
-    "parserOptions": {
-        "ecmaVersion": "latest",
-        "sourceType": "module"
-    },
-    "rules": {
-    }
-}
+  ],
+};

--- a/reader/.prettierignore
+++ b/reader/.prettierignore
@@ -1,0 +1,9 @@
+# Ignore build artifacts
+coverage
+.next
+package-lock.json
+
+*.md
+
+# Ignore all HTML files
+*.html

--- a/reader/.prettierrc
+++ b/reader/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "singleQuote": true,
+  "jsxSingleQuote": false
+}

--- a/reader/lib/migrations/21-nov-2022-string-to-boolean/__test__/fixtures/standard-fixture.js
+++ b/reader/lib/migrations/21-nov-2022-string-to-boolean/__test__/fixtures/standard-fixture.js
@@ -1,0 +1,100 @@
+// Mandated is "false", is_published_standard is "true"
+export const fixture = {
+  assurance: '',
+  author: null,
+  author_email: null,
+  care_setting: [
+    'Community health',
+    'Hospital',
+    'Mental health',
+    'GP / Primary care',
+    'Social care',
+  ],
+  contact_details: 'support@theprsb.org',
+  creator_user_id: 'e696775c-480a-490f-95ba-f684fcc8be29',
+  dependencies:
+    'This standard needs to be reviewed and implemented alongside [SNOMED CT](https://digital.nhs.uk/data-and-information/information-standards/information-standards-and-data-collections-including-extractions/publications-and-notifications/standards-and-collections/scci0034-snomed-ct), FHIR and electronic systems both ends',
+  description:
+    'Standardising information shared so professionals can provide continuity of care when an adult is discharged from mental health services. Includes information on patient history, medications, as well as current and previous diagnoses.',
+  documentation_help_text: '',
+  documentation_link: 'https://theprsb.org/standards/mentalhealth/',
+  endorsements: `"This standard has been endorsed by the following organisations:
+* Royal College of Nursing
+* Royal College of Psychiatrists
+* Association of Directors of Adult Social Services
+* Royal College of General Practitioners
+* Royal College of Occupational Therapists
+* Royal Pharmaceutical Society
+* British Psychological Society
+* RCoA
+* Institute of Health Records and Information Management
+* TechUK"`,
+  id: 'd9e39e81-87f4-4252-b550-f03bcd265393',
+  is_published_standard: 'true',
+  isopen: false,
+  license_id: null,
+  license_title: null,
+  maintainer: null,
+  maintainer_email: null,
+  mandated: 'false',
+  metadata_created: '2021-10-21T09:46:14.324620',
+  metadata_modified: '2022-09-23T09:36:16.356487',
+  name: 'mental-health-inpatient-discharge',
+  notes: null,
+  num_resources: 0,
+  num_tags: 2,
+  organization: {
+    id: '9bbb3855-91ed-4807-8691-d3c1b584e3e3',
+    name: 'professional-record-standards-body',
+    title: 'Professional Record Standards Body',
+    type: 'organization',
+    description: '',
+    image_url: '',
+    created: '2021-10-21T09:34:19.594675',
+    is_organization: true,
+    approval_status: 'approved',
+    state: 'active',
+  },
+  owner_org: '9bbb3855-91ed-4807-8691-d3c1b584e3e3',
+  private: false,
+  reference_code: '',
+  related_standards:
+    'This standard relates to the group of standards by the PRSB known as the transfers of care standards.',
+  standard_category: 'Record standards',
+  state: 'active',
+  status: 'active',
+  submit_feedback: '',
+  title: 'Mental health inpatient discharge',
+  topic: [
+    'Referrals',
+    'Demographics',
+    'Key care information',
+    'Prescribing',
+    'Patient communication',
+    'Information governance',
+    'Tests and diagnostics',
+  ],
+  type: 'dataset',
+  url: null,
+  version: null,
+  tags: [
+    {
+      display_name: 'Record standards',
+      id: 'f726851d-aa35-4763-80d8-c57243303f34',
+      name: 'Record standards',
+      state: 'active',
+      vocabulary_id: null,
+    },
+    {
+      display_name: 'Status - active',
+      id: 'f8faa6be-a595-488a-80d8-c8ad7064429c',
+      name: 'Status - active',
+      state: 'active',
+      vocabulary_id: null,
+    },
+  ],
+  resources: [],
+  groups: [],
+  relationships_as_subject: [],
+  relationships_as_object: [],
+};

--- a/reader/lib/migrations/21-nov-2022-string-to-boolean/__test__/index.test.js
+++ b/reader/lib/migrations/21-nov-2022-string-to-boolean/__test__/index.test.js
@@ -1,0 +1,15 @@
+import { fixture } from './fixtures/standard-fixture';
+import { setValueToBoolean } from '..';
+
+describe('setValueToBoolean', () => {
+  it('set strings to booleans', () => {
+    let record = fixture;
+    expect(record.is_published_standard).toBe('true');
+    expect(record.mandated).toBe('false');
+
+    record = { ...fixture, ...setValueToBoolean(fixture) };
+
+    expect(record.is_published_standard).toBe(true);
+    expect(record.mandated).toBe(false);
+  });
+});

--- a/reader/lib/migrations/21-nov-2022-string-to-boolean/index.js
+++ b/reader/lib/migrations/21-nov-2022-string-to-boolean/index.js
@@ -1,0 +1,8 @@
+export const setValueToBoolean = (record) => {
+  for (const [key, value] of Object.entries(record)) {
+    if (value && typeof value === 'string' && value.match(/true|false/)) {
+      record[key] = value.toLowerCase() === 'true';
+    }
+  }
+  return record;
+};

--- a/reader/lib/write/index.js
+++ b/reader/lib/write/index.js
@@ -6,6 +6,7 @@ import dotenv from 'dotenv';
 import slugify from 'slugify';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { setValueToBoolean } from '../migrations/21-nov-2022-string-to-boolean/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -46,7 +47,7 @@ const writeRecord = async ({ record, headers, ckanUrl, dryRun } = {}) => {
       owner_org: organization.name,
     },
   };
-  let recordToWrite = params;
+  let recordToWrite = setValueToBoolean(params);
 
   if (dryRun) {
     console.log('DRY RUN:');

--- a/reader/write-json-to-ckan.js
+++ b/reader/write-json-to-ckan.js
@@ -24,7 +24,7 @@ program
     
     e.g. to pull records down from the test env and write to prod:
     
-    $ node write-json-to-ckan.js --from 'https://2gv8f9zmci.execute-api.eu-west-2.amazonaws.com/dev/get?key={apiKey}&env=https://manage.test.standards.nhs.uk/api/action' --wrtite-location dev
+    $ node write-json-to-ckan.js --from 'https://2gv8f9zmci.execute-api.eu-west-2.amazonaws.com/dev/get?key={apiKey}&env=https://manage.test.standards.nhs.uk/api/action' --write-location dev
     `
   )
   .version('0.0.0')
@@ -38,6 +38,12 @@ program
       'environment to write to'
     ).choices(['local', 'dev', 'test', 'prod'])
   )
+  .addOption(
+    new Option(
+      '-k, --key <ckan-api-key>',
+      'ckan api key to use if not using a locally configured key'
+    )
+  )
   .option('--dry-run <bool>', 'set dry-run', false);
 
 program.addHelpText('beforeAll', logo);
@@ -45,8 +51,9 @@ program.addHelpText('beforeAll', logo);
 program.parse();
 const opts = program.opts();
 
-const { from: location } = opts;
+const { from: location, key: ckanApiKey } = opts;
 console.log(logo);
+console.log('api key:', ckanApiKey);
 console.log(`fetching records from
 ${location}`);
 
@@ -61,8 +68,10 @@ const mapEnv = (to) =>
 
 const res = await fetch(location);
 const data = await res.json();
+
 await writeToCKAN({
   data, // write directly with json data
   ckanUrl: mapEnv(opts.writeLocation),
+  ckanApiKey,
   dryRun: opts.dryRun,
 });


### PR DESCRIPTION
A quick migrations update which also enables the passing of arbitrary api keys, rather than locally configured ones:

```
CKAN_KEY={myApiKey} && node write-json-to-ckan.js --from \
'https://2gv8f9zmci.execute-api.eu-west-2.amazonaws.com/dev/get?key=$CKAN_KEY&env=https://manage.standards.nhs.uk/api/action' \
--write-location prod --key=$CKAN_KEY
```

Note: this has now been run on all envs and should have set "false" and "true" strings to their corresponding booleans