### PR TITLE
[STAN-1095] Switch all master references to main in workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,7 +24,7 @@ jobs:
       - run: npm test
 
   integrationtest:
-    uses: nhsx/standards-registry/.github/workflows/integration-test.yml@master
+    uses: nhsx/standards-registry/.github/workflows/integration-test.yml@main
     with:
       base_url: http://localhost:3000
       ckan_url: https://manage.test.standards.nhs.uk/api/action

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -3,7 +3,7 @@ name: deploy-dev
 on:
   workflow_run:
     branches:
-      - master
+      - main
     workflows:
       - build-and-test
     types:
@@ -30,7 +30,7 @@ jobs:
       - run: npx serverless deploy --aws-profile=k8sDev --verbose --debug=*
 
   deploy-ui:
-    uses: nhsx/standards-registry/.github/workflows/helm-deploy-ui.yml@master
+    uses: nhsx/standards-registry/.github/workflows/helm-deploy-ui.yml@main
     with:
       environment: dev
     secrets:
@@ -111,7 +111,7 @@ jobs:
       - deploy-csv-exporter
       - deploy-ui
       - ckan
-    uses: nhsx/standards-registry/.github/workflows/integration-test.yml@master
+    uses: nhsx/standards-registry/.github/workflows/integration-test.yml@main
     with:
       base_url: https://dev.standards.nhs.uk
       ckan_url: https://manage.dev.standards.nhs.uk/api/action
@@ -137,7 +137,7 @@ jobs:
   site-quality-test:
     needs:
       - integrationtest
-    uses: nhsx/standards-registry/.github/workflows/lighthouse-test.yml@master
+    uses: nhsx/standards-registry/.github/workflows/lighthouse-test.yml@main
     with:
       test_url: https://dev.standards.nhs.uk
     secrets:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -3,7 +3,7 @@ name: deploy-prod
 on:
   workflow_run:
     branches:
-      - master
+      - main
     workflows:
       - deploy-test
     types:
@@ -13,7 +13,7 @@ on:
 
 jobs:
   deploy-ui:
-    uses: nhsx/standards-registry/.github/workflows/helm-deploy-ui.yml@master
+    uses: nhsx/standards-registry/.github/workflows/helm-deploy-ui.yml@main
     with:
       environment: prod
       ecr_repository: nhsx-standards-directory-prod
@@ -93,7 +93,7 @@ jobs:
     needs:
       - deploy-ui
       - ckan
-    uses: nhsx/standards-registry/.github/workflows/integration-test.yml@master
+    uses: nhsx/standards-registry/.github/workflows/integration-test.yml@main
     with:
       base_url: https://data.standards.nhs.uk
       ckan_url: https://manage.standards.nhs.uk/api/action
@@ -103,7 +103,7 @@ jobs:
     if: ${{ success() }}
     needs:
       - integrationtest
-    uses: nhsx/standards-registry/.github/workflows/link-checker.yml@master
+    uses: nhsx/standards-registry/.github/workflows/link-checker.yml@main
     with:
       base_url: https://data.standards.nhs.uk
       blc_args: --follow true --recursive
@@ -112,7 +112,7 @@ jobs:
     if: ${{ success() }}
     needs:
       - integrationtest
-    uses: nhsx/standards-registry/.github/workflows/sitemap.yml@master
+    uses: nhsx/standards-registry/.github/workflows/sitemap.yml@main
 
   notifypass:
     runs-on: ubuntu-latest
@@ -134,7 +134,7 @@ jobs:
   site-quality-test:
     needs:
       - integrationtest
-    uses: nhsx/standards-registry/.github/workflows/lighthouse-test.yml@master
+    uses: nhsx/standards-registry/.github/workflows/lighthouse-test.yml@main
     with:
       test_url: https://data.standards.nhs.uk
     secrets:

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -3,7 +3,7 @@ name: deploy-test
 on:
   workflow_run:
     branches:
-      - master
+      - main
     workflows:
       - deploy-dev
     types:
@@ -13,7 +13,7 @@ on:
 
 jobs:
   deploy-ui:
-    uses: nhsx/standards-registry/.github/workflows/helm-deploy-ui.yml@master
+    uses: nhsx/standards-registry/.github/workflows/helm-deploy-ui.yml@main
     with:
       environment: test
     secrets:
@@ -89,7 +89,7 @@ jobs:
     needs:
       - deploy-ui
       - ckan
-    uses: nhsx/standards-registry/.github/workflows/integration-test.yml@master
+    uses: nhsx/standards-registry/.github/workflows/integration-test.yml@main
     with:
       base_url: https://test.standards.nhs.uk
       ckan_url: https://manage.test.standards.nhs.uk/api/action
@@ -115,7 +115,7 @@ jobs:
   site-quality-test:
     needs:
       - integrationtest
-    uses: nhsx/standards-registry/.github/workflows/lighthouse-test.yml@master
+    uses: nhsx/standards-registry/.github/workflows/lighthouse-test.yml@main
     with:
       test_url: https://test.standards.nhs.uk
     secrets:


### PR DESCRIPTION
* I've pushed up all symbolic refs in git from `master` to `main`
* Settings have been updated to using `main` as the default branch
* this PR also updates all internal workflow references from `master` to `main`